### PR TITLE
Docker non root

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: entity-api:1.0
     hostname: entity-api
     container_name: entity-api
+    environment:
+      - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image
       - "../src/instance:/usr/src/app/src/instance"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     hostname: entity-api
     container_name: entity-api
     environment:
+      - HOST_GID=1000
       - HOST_UID=1000
     volumes:
       # Mount the app config to container in order to keep it outside of the image

--- a/docker/entity-api/Dockerfile
+++ b/docker/entity-api/Dockerfile
@@ -1,8 +1,7 @@
 # Parent image
 FROM hubmap/api-base-image:latest
 
-LABEL description="HuBMAP Entity API Service" \
-	version="1.0"
+LABEL description="HuBMAP Entity API Service"
 
 # Change to directory that contains the Dockerfile
 WORKDIR /usr/src/app
@@ -16,6 +15,12 @@ RUN pip install -r src/requirements.txt
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.
 EXPOSE 5000
+
+# Set an entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Finally, we run uWSGI with the ini file
 CMD [ "uwsgi", "--ini", "/usr/src/app/src/uwsgi.ini" ]

--- a/docker/entity-api/entrypoint.sh
+++ b/docker/entity-api/entrypoint.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose,
 # defaulting to 9000 if it doesn't exist
+HOST_GID=${HOST_GID:-9000}
 HOST_UID=${HOST_UID:-9000}
 
-echo "Starting entity-api container with the same host UID: $HOST_UID"
+echo "Starting entity-api container with the same host user UID: $HOST_UID and GID: $HOST_GID"
 
 # Create a new user with the same host UID to run processes on container
 # The Filesystem doesn't really care what the user is called,
 # it only cares about the UID attached to that user
-useradd -r -u $HOST_UID -o -c "" -m hubmap
+# Check if user already exists and don't recreate across container restarts
+getent passwd $HOST_UID > /dev/null 2&>1
+# $? is a special variable that captures the exit status of last task
+if [ $? -ne 0 ]; then
+    groupadd -r -g $HOST_GID hubmap
+    useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
+fi
 
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments

--- a/docker/entity-api/entrypoint.sh
+++ b/docker/entity-api/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Pass the HOST_UID from an environment variable specified in the child image docker-compose,
+# defaulting to 9000 if it doesn't exist
+HOST_UID=${HOST_UID:-9000}
+
+echo "Starting entity-api container with the same host UID: $HOST_UID"
+
+# Create a new user with the same host UID to run processes on container
+# The Filesystem doesn't really care what the user is called,
+# it only cares about the UID attached to that user
+useradd -r -u $HOST_UID -o -c "" -m hubmap
+
+# Lastly we use gosu to execute our process "$@" as that user
+# Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
+# "$@" is a shell variable that means "all the arguments"
+exec /usr/local/bin/gosu hubmap "$@"


### PR DESCRIPTION
This PR:

- de-elevates root to hubmap user (mapped with the host UID and GID) for running nginx, uwsgi and docker processes
- the docker-compose takes UID and GID as new environment variables for passing host user info to docker container
- internal ports changes to allow nginx run as non-root process