### PR TITLE
Entity access level zhou

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -188,6 +188,11 @@ def get_entity_access_level(uuid):
         logger.error(msg, exc_info=True)
         print(msg)
         return Response(msg, 500)
+    except Exception as e:
+        msg = 'Unhandled exception occured, check log file for detail'
+        print (msg)
+        logger.error(msg, exc_info=True)
+        return Response(msg, 500)
 
 
 @app.route('/entities/uuid/<uuid>', methods = ['GET'])

--- a/src/app.py
+++ b/src/app.py
@@ -180,13 +180,12 @@ def get_entity_access_level(uuid):
         return dataset.get_entity_access_level(uuid)
     except HTTPException as hte:
         msg = "HTTPException during get_entity_access_level HTTP code: " + str(hte.get_status_code()) + " " + hte.get_description() 
-        print(msg)
         logger.warn(msg, exc_info=True)
         return Response(hte.get_description(), hte.get_status_code())
     except CypherError as ce:
-        print ('A Cypher error was encountered when calling dataset.get_entity_access_level(): ' + ce.message)
-        logger.error(ce, exc_info=True)
-        return Response('A Cypher error was encountered when calling dataset.get_entity_access_level(), check log file for detail', 500)
+        msg = 'A Cypher error was encountered when calling dataset.get_entity_access_level(), check log file for detail'
+        logger.error(msg, exc_info=True)
+        return Response(msg, 500)
 
 
 @app.route('/entities/uuid/<uuid>', methods = ['GET'])

--- a/src/app.py
+++ b/src/app.py
@@ -181,10 +181,12 @@ def get_entity_access_level(uuid):
     except HTTPException as hte:
         msg = "HTTPException during get_entity_access_level HTTP code: " + str(hte.get_status_code()) + " " + hte.get_description() 
         logger.warn(msg, exc_info=True)
+        print(msg)
         return Response(hte.get_description(), hte.get_status_code())
     except CypherError as ce:
         msg = 'A Cypher error was encountered when calling dataset.get_entity_access_level(), check log file for detail'
         logger.error(msg, exc_info=True)
+        print(msg)
         return Response(msg, 500)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -183,10 +183,10 @@ def get_entity_access_level(uuid):
         print(msg)
         logger.warn(msg, exc_info=True)
         return Response(hte.get_description(), hte.get_status_code())
-    except Exception as e:
-        print ('An unexpected error occurred. Check log file.')
+    except CypherError as ce:
+        print ('A Cypher error was encountered when calling dataset.get_entity_access_level(): ' + e.message)
         logger.error(e, exc_info=True)
-        return Response('Unhandled exception occured', 500)
+        return Response('A Cypher error was encountered when calling dataset.get_entity_access_level(), check log file for detail', 500)
 
 
 @app.route('/entities/uuid/<uuid>', methods = ['GET'])

--- a/src/app.py
+++ b/src/app.py
@@ -184,8 +184,8 @@ def get_entity_access_level(uuid):
         logger.warn(msg, exc_info=True)
         return Response(hte.get_description(), hte.get_status_code())
     except CypherError as ce:
-        print ('A Cypher error was encountered when calling dataset.get_entity_access_level(): ' + e.message)
-        logger.error(e, exc_info=True)
+        print ('A Cypher error was encountered when calling dataset.get_entity_access_level(): ' + ce.message)
+        logger.error(ce, exc_info=True)
         return Response('A Cypher error was encountered when calling dataset.get_entity_access_level(), check log file for detail', 500)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -170,6 +170,25 @@ def get_entity(identifier):
             msg += str(x)
         abort(400, msg)
 
+
+# Get data_access_level for a given entity uuid (Donor/Sample/Dataset)
+@app.route('/entity-access-level/<uuid>', methods = ['GET'])
+@secured(groups="HuBMAP-read")
+def get_entity_access_level(uuid):
+    try:
+        dataset = Dataset(app.config)
+        return dataset.get_entity_access_level(uuid)
+    except HTTPException as hte:
+        msg = "HTTPException during get_entity_access_level HTTP code: " + str(hte.get_status_code()) + " " + hte.get_description() 
+        print(msg)
+        logger.warn(msg, exc_info=True)
+        return Response(hte.get_description(), hte.get_status_code())
+    except Exception as e:
+        print ('An unexpected error occurred. Check log file.')
+        logger.error(e, exc_info=True)
+        return Response('Unhandled exception occured', 500)
+
+
 @app.route('/entities/uuid/<uuid>', methods = ['GET'])
 # @cross_origin(origins=[app.config['UUID_UI_URL']], methods=['GET'])
 def get_entity_by_uuid(uuid):

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -262,9 +262,9 @@ class Dataset(object):
             driver = conn.get_driver()
             return_list = []
             with driver.session() as session:
-                    for record in session.run(query):
-                        #return_list.append(record)
-                        return_list.append(record['acc_level'])
+                for record in session.run(query):
+                    #return_list.append(record)
+                    return_list.append(record['acc_level'])
             
             if len(return_list) == 0:
                 raise HTTPException("Entity uuid:" + uuid + " not found.", 404)

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -273,10 +273,11 @@ class Dataset(object):
                 raise HTTPException("Entity uuid:" + uuid + " not found.", 404)
             if len(return_list) > 1:
                 raise HTTPException("Multiple entities found for uuid: " + uuid, 500)
-            return return_list[0]
-                        
+            return return_list[0]           
         except CypherError as ce:
             raise CypherError('A Cypher error was encountered: ' + ce.message)
+        except Exception as e:
+            raise Exception('Unhandled Exception occurred: ' + e.message)
         finally:
             if driver is not None:
                 driver.close()

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -274,9 +274,8 @@ class Dataset(object):
                 raise HTTPException("Multiple entities found for uuid: " + uuid, 500)
             return return_list[0]
                         
-        except CypherError as e:
-            print ('A Cypher error was encountered: ' + e.message)
-            raise CypherError('A Cypher error was encountered: ' + e.message)
+        except CypherError as ce:
+            raise CypherError('A Cypher error was encountered: ' + ce.message)
         finally:
             if driver is not None:
                 driver.close()

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -254,10 +254,10 @@ class Dataset(object):
                 raise
 
     @classmethod
-    def get_dataset_access_level(self, uuid):
+    def get_entity_access_level(self, uuid):
         driver = None
         try:
-            query = "match (e:Entity {entitytype: 'Dataset'})-[:HAS_METADATA]-(m:Metadata) where e.uuid = '" + uuid + "' return m.data_access_level as acc_level"
+            query = "match (e:Entity)-[:HAS_METADATA]-(m:Metadata) where e.uuid = '" + uuid + "' return m.data_access_level as acc_level"
             conn = Neo4jConnection(self.confdata['NEO4J_SERVER'], self.confdata['NEO4J_USERNAME'], self.confdata['NEO4J_PASSWORD'])
             driver = conn.get_driver()
             return_list = []
@@ -267,9 +267,9 @@ class Dataset(object):
                         return_list.append(record['acc_level'])
             
             if len(return_list) == 0:
-                raise HTTPException("Dataset uuid:" + uuid + " not found.", 404)
+                raise HTTPException("Entity uuid:" + uuid + " not found.", 404)
             if len(return_list) > 1:
-                raise HTTPException("Multiple datasets found for uuid:" + uuid, 500)
+                raise HTTPException("Multiple entities found for uuid:" + uuid, 500)
             return return_list[0]
                         
         except Exception as e:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -257,7 +257,8 @@ class Dataset(object):
     def get_entity_access_level(self, uuid):
         driver = None
         try:
-            query = "match (e:Entity)-[:HAS_METADATA]->(m:Metadata) where e.uuid = '" + uuid + "' return m.data_access_level as acc_level"
+            query = "match (e:Entity)-[:HAS_METADATA]->(m:Metadata) where e.{uuid_attr} = '{uuid}' return m.{data_access_attr} as acc_level".format(
+                data_access_attr=HubmapConst.DATA_ACCESS_LEVEL,uuid_attr=HubmapConst.UUID_ATTRIBUTE,uuid=uuid)
             conn = Neo4jConnection(self.confdata['NEO4J_SERVER'], self.confdata['NEO4J_USERNAME'], self.confdata['NEO4J_PASSWORD'])
             driver = conn.get_driver()
             return_list = []
@@ -1707,3 +1708,14 @@ def convert_dataset_status(raw_status):
         new_status = HubmapConst.DATASET_STATUS_HOLD
     return new_status
 
+if __name__ == "__main__":
+    NEO4J_SERVER = 'bolt://localhost:7687'
+    NEO4J_USERNAME = 'neo4j'
+    NEO4J_PASSWORD = '123'
+
+    conf_data = {'NEO4J_SERVER' : NEO4J_SERVER, 'NEO4J_USERNAME': NEO4J_USERNAME, 
+                 'NEO4J_PASSWORD': NEO4J_PASSWORD}
+    dataset = Dataset(conf_data)
+    uuid = 'd4a9d88b24f460f30a50475b63d66cd5'
+    access_level = dataset.get_entity_access_level(uuid)
+    print('access_level: ' + access_level)


### PR DESCRIPTION
- added new API endpoint `/entity-access-level/<uuid>` to return the access level as string for a given entity
- this endpoint calls the `dataset. get_entity_access_level()`
- improved error handling
- also added this new endpoint in gateway (in a separate branch now) and the auth requires HuBMAP-Read group.

@shirey @cborromeo please review and merge if all looks good. I've tested and it works with the gateway on DEV. One issue I noticed is that in the DEV version of neo4j, many of the entity nodes don't have the `data_access_level` attribute at this point since it's newly added.