### PR TITLE
Entity access level enhancement zhou

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -176,6 +176,13 @@ def get_entity(identifier):
 @secured(groups="HuBMAP-read")
 def get_entity_access_level(uuid):
     try:
+        #get the id from the UUID service to resolve to a UUID and check to make sure that it exists
+        ug = UUID_Generator(app.config['UUID_WEBSERVICE_URL'])
+        hmuuid_data = ug.getUUID(AuthHelper.instance().getProcessSecret(), identifier)
+        if hmuuid_data is None or len(hmuuid_data) == 0:
+            return Response("UUID: " + identifier + " not found.", 404)
+        
+        # If the UUID exists, we go get the data_access_level
         dataset = Dataset(app.config)
         return dataset.get_entity_access_level(uuid)
     except HTTPException as hte:

--- a/src/app.py
+++ b/src/app.py
@@ -178,9 +178,9 @@ def get_entity_access_level(uuid):
     try:
         #get the id from the UUID service to resolve to a UUID and check to make sure that it exists
         ug = UUID_Generator(app.config['UUID_WEBSERVICE_URL'])
-        hmuuid_data = ug.getUUID(AuthHelper.instance().getProcessSecret(), identifier)
+        hmuuid_data = ug.getUUID(AuthHelper.instance().getProcessSecret(), uuid)
         if hmuuid_data is None or len(hmuuid_data) == 0:
-            return Response("UUID: " + identifier + " not found.", 404)
+            return Response("UUID: " + uuid + " not found.", 404)
         
         # If the UUID exists, we go get the data_access_level
         dataset = Dataset(app.config)

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -270,7 +270,9 @@ class Dataset(object):
                         return_list.append(record['acc_level'])
             
             if len(return_list) == 0:
-                raise HTTPException("Entity uuid:" + uuid + " not found.", 404)
+                # Handle this as the metadata node doesn't have `data_access_level` attribute 
+                # Return the access level as "protected" by default
+                return HubmapConst.ACCESS_LEVEL_PROTECTED 
             if len(return_list) > 1:
                 raise HTTPException("Multiple entities found for uuid: " + uuid, 500)
             return return_list[0]           


### PR DESCRIPTION
- added existence check for a given uuid before making a cypher call to get data_access_level
- return a default data_access_level as 'protected' when the attribute in metadata node is missing