### PR TITLE
Shirey/file upload

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -305,7 +305,7 @@ ENTITIES:
         description: "List of uploaded image files and descriptions of the files. Stored in db as a stringfied json array."
         # Only image file descriptions are allowed to be updated
         # Adding or deleting image files must via the other two properties
-        before_update_trigger: update_image_files_descriptions
+        before_update_trigger: update_file_descriptions
       image_files_to_add:
         type: list 
         transient: true
@@ -468,4 +468,48 @@ ENTITIES:
       visit:
         type: string
         description: "The visit id for the donor/patient when the sample was obtained."
+      image_files:
+        # This property has no trigger method, but will be created via `image_files_to_add` and updated via `image_files_to_delete`
+        type: list 
+        generated: true # Disallow direct user input from create via POST, but can be used for update via PUT
+        description: "List of uploaded image files and descriptions of the files. Stored in db as a stringfied json array."
+        # Only image file descriptions are allowed to be updated
+        # Adding or deleting image files must via the other two properties
+        before_update_trigger: update_file_descriptions
+      image_files_to_add:
+        type: list 
+        transient: true
+        exposed: false
+        description: 'List of temporary file ids with an optional description. Provide as a json array with an temp_file_id and description attribute for each element like {"files": [{"temp_file_id":"dzevgd6xjs4d5grmcp4n","description":"This is image file one"},{"temp_file_id":"yrahjadfhadf","description":"This is image file two"}]}'
+        before_create_trigger: commit_image_files
+        before_update_trigger: commit_image_files
+      image_files_to_remove:
+        # This is only valid on update via a PUT request
+        type: list 
+        transient: true
+        exposed: false
+        description: 'List of image files previously uploaded to delete. Provide as a json array of the file_uuids of the file like: ["232934234234234234234270c0ea6c51d604a850558ef2247d0b4", "230948203482234234234a57bfe9c056d08a0f8e6cd612baa3bfa"]'
+        before_update_trigger: delete_image_files
+      metadata_files:
+        # This property has no trigger method, but will be created via `metadata_files_to_add` and updated via `metadata_files_to_delete`
+        type: list 
+        generated: true # Disallow direct user input from create via POST, but can be used for update via PUT
+        description: "List of uploaded image files and descriptions of the files. Stored in db as a stringfied json array."
+        # Only image file descriptions are allowed to be updated
+        # Adding or deleting image files must via the other two properties
+        before_update_trigger: update_file_descriptions
+      metadata_files_to_add:
+        type: list 
+        transient: true
+        exposed: false
+        description: 'List of temporary file ids with an optional description. Provide as a json array with an temp_file_id and description attribute for each element like {"files": [{"temp_file_id":"dzevgd6xjs4d5grmcp4n","description":"This is image file one"},{"temp_file_id":"yrahjadfhadf","description":"This is image file two"}]}'
+        before_create_trigger: commit_metadata_files
+        before_update_trigger: commit_metadata_files
+      metadata_files_to_remove:
+        # This is only valid on update via a PUT request
+        type: list 
+        transient: true
+        exposed: false
+        description: 'List of image files previously uploaded to delete. Provide as a json array of the file_uuids of the file like: ["232934234234234234234270c0ea6c51d604a850558ef2247d0b4", "230948203482234234234a57bfe9c056d08a0f8e6cd612baa3bfa"]'
+        before_update_trigger: delete_metadata_files
 

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -906,7 +906,7 @@ def create_hubmap_ids(normalized_class, json_data_dict, user_token, user_info_di
                 # Validate the group_uuid and make sure it's one of the valid data providers
                 # and the user also belongs to this group
                 try:
-                    schema_manager.validate_entity_group_uuid(group_uuid, user_group_uuids)
+                    validate_entity_group_uuid(group_uuid, user_group_uuids)
                 except schema_errors.NoDataProviderGroupException as e:
                     # No need to log
                     raise schema_errors.NoDataProviderGroupException(e)

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1013,7 +1013,7 @@ Returns
 dict
     The group info (group_uuid and group_name)
 """
-def get_entity_group_info(user_hmgroupids_list):
+def get_entity_group_info(user_hmgroupids_list, default_group = None):
     # Default
     group_info = {
         'uuid': '',
@@ -1042,13 +1042,16 @@ def get_entity_group_info(user_hmgroupids_list):
         raise schema_errors.NoDataProviderGroupException(msg)
 
     if len(user_data_provider_uuids) > 1:
-        msg = "More than one data_provider groups found for this user. Can't continue."
-        # Log the full stack trace, prepend a line with our message
-        logger.exception(msg)
-        raise schema_errors.MultipleDataProviderGroupException(msg)
-
-    # By now only one data provider group found, this is what we want
-    uuid = user_data_provider_uuids[0]
+        if not default_group is None and default_group in user_hmgroupids_list:
+            uuid = default_group
+        else:
+                msg = "More than one data_provider groups found for this user and no group_uuid specified. Can't continue."
+                # Log the full stack trace, prepend a line with our message
+                logger.exception(msg)
+                raise schema_errors.MultipleDataProviderGroupException(msg)
+    else:
+        # By now only one data provider group found, this is what we want
+        uuid = user_data_provider_uuids[0]
     group_info['uuid'] = uuid
     group_info['name'] = groups_by_id_dict[uuid]['displayname']
     

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1051,7 +1051,7 @@ def link_sample_to_direct_ancestor(property_key, normalized_type, user_token, ex
     logger.debug(activity_json_list_str)
 
     try:
-        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], direct_ancestor_uuid, activity_json_list_str)
+        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], existing_data_dict['direct_ancestor_uuid'], activity_json_list_str)
     except TransactionError:
         # No need to log
         raise

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -774,7 +774,7 @@ def get_local_directory_rel_path(property_key, normalized_type, user_token, exis
 
 
 """
-Trigger event method to ONLY update descriptions of existing image files
+Trigger event method to ONLY update descriptions of existing files
 
 Parameters
 ----------
@@ -794,22 +794,22 @@ Returns
 str: The target property key
 list: The file info dicts (with updated descriptions) in a list
 """
-def update_image_files_descriptions(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+def update_file_descriptions(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
     if property_key not in new_data_dict:
-        raise KeyError(f"Missing '{property_key}' key in 'new_data_dict' during calling 'update_image_files_descriptions()' trigger method.")
+        raise KeyError(f"Missing '{property_key}' key in 'new_data_dict' during calling 'update_file_descriptions()' trigger method.")
 
     if property_key not in existing_data_dict:
-        raise KeyError(f"Missing '{property_key}' key in 'existing_data_dict' during calling 'update_image_files_descriptions()' trigger method.")
+        raise KeyError(f"Missing '{property_key}' key in 'existing_data_dict' during calling 'update_file_descriptions()' trigger method.")
 
-    # 'image_files' must be a json array
+    # The property holding the file information must be a json array
     if not isinstance(new_data_dict[property_key], list):
-        raise TypeError(f"'{property_key}' value in 'new_data_dict' must be a list during calling 'update_image_files_descriptions()' trigger method.")
+        raise TypeError(f"'{property_key}' value in 'new_data_dict' must be a list during calling 'update_file_descriptions()' trigger method.")
 
     file_info_by_uuid_dict = {}
     # Convert the string literal to list
-    existing_image_files_list = ast.literal_eval(existing_data_dict[property_key])
+    existing_files_list = ast.literal_eval(existing_data_dict[property_key])
 
-    for file_info in existing_image_files_list:
+    for file_info in existing_files_list:
         file_uuid = file_info['file_uuid']
 
         file_info_by_uuid_dict[file_uuid] = file_info
@@ -828,14 +828,14 @@ def update_image_files_descriptions(property_key, normalized_type, user_token, e
 
 
 """
-Trigger event method to commit image files save that were previously uploaded with UploadFileHelper.save_file
+Trigger event method to commit files saved that were previously uploaded with UploadFileHelper.save_file
 
-The information, filename and optional description is saved in the image_files field 
+The information, filename and optional description is saved in the field with name specified by `target_property_key`
 in the provided data_dict.  The image files needed to be previously uploaded
 using the temp file service (UploadFileHelper.save_file).  The temp file id provided
 from UploadFileHelper, paired with an optional description of the file must be provided
 in the field `image_files_to_add` in the data_dict for each file being committed
-in a JSON array like below (image "description" is optional): 
+in a JSON array like below ("description" is optional): 
 
 [
   {
@@ -871,19 +871,27 @@ str: The target property key
 list: The file info dicts in a list
 """
 def commit_image_files(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
-    # Do nothing if no `image_files_to_add` provided from request
-    # Or `image_files_to_add` is empty
+    return __commit_image_files('image_files', property_key, normalized_type, user_token, existing_data_dict, new_data_dict)
+
+def commit_metadata_files(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+    return __commit_image_files('metadata_files', property_key, normalized_type, user_token, existing_data_dict, new_data_dict)
+
+def __commit_image_files(target_property_key, property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+    
+    # Do nothing if no files to add are provided (missing or empty property)
+    #for image files the property name is "image_files_to_add" for metadata
+    #files the property name is "metadata_files_to_add", but other may be used in
+    #the future
     if (not property_key in new_data_dict) or (not new_data_dict[property_key]):
         return property_key, None
-
-    target_property_key = 'image_files'
-
+    
+    
     # If POST or PUT where the target doesn't exist create the file info array
     if not target_property_key in existing_data_dict:
         files_info_list = []
     # Otherwise this is a PUT where the target array exists already
     else:
-        # Note: The property `image_files` value is stored in Neo4j as a string representation of the Python list
+        # Note: The property, name specified by `target_property_key`, is stored in Neo4j as a string representation of the Python list
         # It's not stored in Neo4j as a json string! And we can't store it as a json string 
         # due to the way that Cypher handles single/double quotes.
         files_info_list = ast.literal_eval(existing_data_dict[target_property_key])
@@ -917,10 +925,13 @@ def commit_image_files(property_key, normalized_type, user_token, existing_data_
 
 
 """
-Trigger event method of removing image files from an entity during update
+Trigger event methods for removing files from an entity during update
 
-Image files are stored in a json encoded text field named `image_files` in the entity dict
-The images to remove are specified as filenames in the `image_files_to_remove` field
+Files are stored in a json encoded text field with property name 'target_property_key' in the entity dict
+The files to remove are specified as file uuids in the `property_key` field
+
+The two outer methods (delete_image_files and delete_metadata_files) pass the target property
+field name to private method, __delete_files along with the other required trigger properties
 
 Parameters
 ----------
@@ -935,31 +946,39 @@ existing_data_dict : dict
 new_data_dict : dict
     A merged dictionary that contains all possible input data to be used
 
+-----------
+target_property_key: str
+    The name of the property where the file information is stored
+
 Returns
 -------
 str: The target property key
 list: The file info dicts in a list
 """
 def delete_image_files(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
-    # Do nothing if no `image_files_to_delete` provided from request
-    # Or `image_files_to_delete` is empty
+    return __delete_files('image_files', property_key, normalized_type, user_token, existing_data_dict, new_data_dict)
+
+def delete_metadata_files(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+    return __delete_files('metadata_files', property_key, normalized_type, user_token, existing_data_dict, new_data_dict)
+    
+def __delete_files(target_property_key, property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+
+    #do nothing if no files to delete are provided in the field specified by property_key
     if (not property_key in new_data_dict) or (not new_data_dict[property_key]):
         return property_key, None
 
-    target_property_key = 'image_files'
-
     if 'uuid' not in existing_data_dict:
-        raise KeyError("Missing 'uuid' key in 'existing_data_dict' during calling 'delete_image_files()' trigger method.")
+        raise KeyError(f"Missing 'uuid' key in 'existing_data_dict' during calling '__delete_files()' trigger method for property '{target_property_key}'.")
     
     if target_property_key not in existing_data_dict:
-        raise KeyError(f"Missing '{target_property_key}' key in 'existing_data_dict' during calling 'delete_image_files()' trigger method.")
+        raise KeyError(f"Missing '{target_property_key}' key in 'existing_data_dict' during calling '_delete_files()' trigger method.")
 
     try:
         entity_uuid = existing_data_dict['uuid']
         # `upload_dir` is already normalized with trailing slash
         entity_upload_dir = schema_manager.get_file_upload_helper_instance().upload_dir + entity_uuid + os.sep
         
-        # Note: The property `image_files` value is stored in Neo4j as a string representation of the Python list
+        # Note: The property named by target_property_key value is stored in Neo4j as a string representation of the Python list
         # It's not stored in Neo4j as a json string! And we can't store it as a json string 
         # due to the way that Cypher handles single/double quotes.
         files_info_list = ast.literal_eval(existing_data_dict[target_property_key])

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -983,7 +983,7 @@ def link_sample_to_direct_ancestor(property_key, normalized_type, user_token, ex
     activity_data_dict = create_activity_data(normalized_type, user_token)
 
     try:
-        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], existing_data_dict['direct_ancestor_uuid'], activity_json_list_str)
+        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], existing_data_dict['direct_ancestor_uuid'], activity_data_dict)
     except TransactionError:
         # No need to log
         raise
@@ -1018,7 +1018,7 @@ def relink_sample_to_direct_ancestor(property_key, normalized_type, user_token, 
     activity_data_dict = create_activity_data(normalized_type, user_token)
 
     try:
-        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], direct_ancestor_uuid, activity_data_dict)
+        schema_neo4j_queries.link_entity_to_direct_ancestor(schema_manager.get_neo4j_driver_instance(), existing_data_dict['uuid'], existing_data_dict['direct_ancestor_uuid'], activity_data_dict)
     except TransactionError:
         # No need to log
         raise

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -359,7 +359,10 @@ def set_group_name(property_key, normalized_type, user_token, existing_data_dict
         raise KeyError("Missing 'hmgroupids' key in 'new_data_dict' during calling 'set_group_name()' trigger method.")
     
     try:
-        group_info = schema_manager.get_entity_group_info(new_data_dict['hmgroupids'])
+        default_group_uuid = None
+        if 'group_uuid' in new_data_dict:
+            default_group_uuid = new_data_dict['group_uuid']
+        group_info = schema_manager.get_entity_group_info(new_data_dict['hmgroupids'], default_group_uuid)
         group_name = group_info['name']
     except schema_errors.NoDataProviderGroupException as e:
         # No need to log


### PR DESCRIPTION
 - added Sample.image_files, Sample.image_files_to_add, Sample.image_files_to_delete, Sample.metadata_files, Sample.metadata_files_to_add and Sample.metadata_files_to_delete attributes
 - remove reference to schema_manager from within schema manager (passing in group_uuid was broken)
 - Fixed bug that didn't allow group_uuid to be specified for users who are members of multiple groups
 - Fixed bug that didn't allow a sample to be linked because variable direct_ancestor_uuid didn't exist