### PR TITLE
Remove hubmap_base_id when generating multiple samples

### DIFF
--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1361,6 +1361,10 @@ def create_hubmap_ids(normalized_class, json_data_dict, user_token, user_info_di
         """
         ids_list = response.json()
 
+        # Remove the "hubmap_base_id" key
+        for d in ids_list:
+        	d.pop('hubmap_base_id')
+
         logger.debug("======create_hubmap_ids() generated ids from uuid-api======")
         logger.debug(ids_list)
 


### PR DESCRIPTION
Will also need to run the Cypher query to remove the `hubmap_base_id` property from Neo4j:

````
MATCH (n:Sample)
WHERE n.hubmap_base_id IS NOT NULL
REMOVE n.hubmap_base_id
RETURN count(n)
````