### PR TITLE
Dataset.lab_dataset_id

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -243,7 +243,7 @@ ENTITIES:
         description: "The dataset title."
       lab_dataset_id:
         type: string
-        description: "The lab dataset id"
+        description: "A name or identifier used by the lab who is uploading the data to cross reference the data locally"
       data_types:
         type: list
         required_on_create: true # Only required for create via POST, not update via PUT

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -241,6 +241,9 @@ ENTITIES:
         type: string
         required_on_create: true # Only required for create via POST, not update via PUT
         description: "The dataset title."
+      lab_dataset_id:
+        type: string
+        description: "The lab dataset id"
       data_types:
         type: list
         required_on_create: true # Only required for create via POST, not update via PUT

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -239,7 +239,6 @@ ENTITIES:
         after_update_trigger: update_dataset_and_ancestors_data_access_level
       title:
         type: string
-        required_on_create: true # Only required for create via POST, not update via PUT
         description: "The dataset title."
       lab_dataset_id:
         type: string


### PR DESCRIPTION
To address  https://github.com/hubmapconsortium/entity-api/issues/152

- Add `lab_dataset_id` for Dataset
- `Dataset.title` is no longer required on create

> copy existing values of Dataset.title to lab_dataset_id

Will need to execute this Cypher query in Neo4j:
````
MATCH (n:Dataset) 
WHERE n.title IS NOT NULL
SET n.lab_dataset_id=n.title
RETURN n.title, n.lab_dataset_id
````

Will also need to trigger a reindex to get this new filed into ES. The ingest-ui displays the table view by pulling information from search-api.