### PR TITLE
Separating revisions and retract methods into 2 separate branches. Th…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,9 +4,7 @@ import os
 import re
 import csv
 import requests
-import json
 import urllib
-import collections
 # Don't confuse urllib (Python native library) with urllib3 (3rd-party library, requests also uses urllib3)
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from pathlib import Path

--- a/src/app.py
+++ b/src/app.py
@@ -1956,6 +1956,13 @@ def get_dataset_revision_number(id):
     return jsonify(revision_number)
 
 
+"""
+Retrieve a list of all revisions of a dataset from the id of any dataset in the chain. 
+E.g: If there are 5 revisions, and the id for revision 4 is given, a list of revisions
+1-5 will be returned in reverse order (newest first). Non-public access is only required to 
+retrieve information on non-published datasets. Output will be a list of dictionaries. Each dictionary
+contains the dataset revision number, its uuid, and then the complete dataset (optional).   
+"""
 
 @app.route('/datasets/<id>/revisions', methods=['GET'])
 def get_revisions_list(id):


### PR DESCRIPTION
Separated datasets/<id>/revisions and datasets/<id>/retract into 2 separate feature branches. Retract is still a work in progress (PR changed to draft). This one passed all local testing and is ready to be tested on dev-integrate assuming no merge conflicts or requested changes. 