### PR TITLE
Derek furst/validate new entity revisions

### DIFF
--- a/entity-api-spec.yaml
+++ b/entity-api-spec.yaml
@@ -1424,3 +1424,60 @@ paths:
           description: The target dataset could not be found
         '500':
           description: Internal error
+  '/datasets/{id}/revisions':
+    get:
+      summary: 'From a given ID of a versioned dataset, retrieve a list of every dataset in the chain ordered from most recent to oldest. The revision number, as well as the dataset uuid will be included. An optional parameter ?include_dataset=true will include the full dataset for each revision as well. Public/Consortium access rules apply, if is for a non-public dataset and no token or a token without membership in HuBMAP-Read group is sent with the request then a 403 response should be returned. If the given id is published, but later revisions are not and the user is not in HuBMAP-Read group, only published revisions will be returned. The field next_revision_uuid will not be returned if the next revision is unpublished'
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier of entity.  This identifier can be either an HuBMAP ID (e.g. HBM123.ABCD.456) or UUID
+          required: true
+          schema:
+            type: string
+        - name: include_dataset
+          in: query
+          description: A case insensitive string. Any value besides true will have no effect. If the string is 'true', the full dataset for each revision will be included in the response
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The revision number (integer) on successful operation
+        '400':
+          description: Invalid or misformatted entity identifier, or the given entity is not a Dataset
+        '401':
+          description: The user's token has expired or the user did not supply a valid token
+        '403':
+          description: The user is not authorized to query the revision number of the given dataset.
+        '404':
+          description: The target dataset could not be found
+        '500':
+          description: Internal error
+  '/datasets/{id}/retract':
+    put:
+      summary: 'Takes a json with a single required field {retraction_reason: string}. The dataset for the given id is modified to include this new retraction_reason field and sets the property sub_status to retracted. The complete modified dataset is returned. This will not work for anything besides published datasets. If the user has no token or has a token without membership in HuBMAP-Data-Admin group, then a 403 response should be returned.'
+      parameters:
+        - name: id
+        in: path
+        description: The unique identifier of entity. This identifier can be either a HubMAP ID (e.g. HBM123.ABCD.456) or UUID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              retraction_reason: string
+      responses:
+        '200':
+          description: The complete dataset with modified sub_status and retraction_reason
+        '400':
+          description: Invalid or misformatted entity identifier, or the given entity is not a Dataset or is not published
+        '401':
+          description: The user's token has expired or the user did not supply a valid token
+        '403':
+          description: The user is not authorized to query the retract the given dataset.
+        '404':
+          description: The target dataset could not be found
+        '500':
+          description: Internal error

--- a/src/app.py
+++ b/src/app.py
@@ -867,6 +867,11 @@ def create_entity(entity_type):
             if next_revisions_list:
                 bad_request_error(f"The previous_revision_uuid specified for this dataset has already had a next revision")
 
+            # Only published datasets can have revisions made of them. Verify that that status of the Dataset specified
+            # by previous_revision_uuid is published. Else, bad request error.
+            if previous_version_dict['status'].lower() != DATASET_STATUS_PUBLISHED:
+                bad_request_error(f"The previous_revision_uuid specified for this dataset must be 'Published' in order to create a new revision from it")
+
         # Generate 'before_create_triiger' data and create the entity details in Neo4j
         merged_dict = create_entity_details(request, normalized_entity_type, user_token, json_data_dict)
     else:


### PR DESCRIPTION
Added validation that checks that when a new dataset is created and points to a previous dataset as a previous revision, make sure that the previous dataset is published. If its not published, throws a bad_request_error. 