### PR TITLE
Derek furst/get associated organs from dataset

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2193,7 +2193,12 @@ def get_associated_organs_from_dataset(id):
     if len(associated_organs) < 1:
         not_found_error("the dataset does not have any associated organs")
 
-    return jsonify(associated_organs)
+    complete_entities_list = schema_manager.get_complete_entities_list(token, associated_organs)
+
+    # Final result after normalization
+    final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+
+    return jsonify(final_result)
 
 ####################################################################################################
 ## Internal Functions

--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -906,7 +906,7 @@ def get_associated_organs_from_dataset(neo4j_driver, dataset_uuid):
     query = (f"MATCH (ds:Dataset)<-[*]-(organ:Sample {{specimen_type:'organ'}}) "
              f"WHERE ds.uuid='{dataset_uuid}'"
              f"RETURN apoc.coll.toSet(COLLECT(organ)) AS {record_field_name}")
-    logger.debug("======get_associated_organs_from_sample() query======")
+    logger.debug("======get_associated_organs_from_dataset() query======")
     logger.debug(query)
 
     with neo4j_driver.session() as session:


### PR DESCRIPTION
Implemented method get_asociated_organs_from_dataset(id) at endpoint /datasets/<id>/organs.

Takes an id for a dataset and runs a neo4j query to return every organ associated with this dataset. If no organ is found, given id is not to a dataset, user has bad token, or user has insufficient permissions, it fails. 