### PR TITLE
change revisions method to not specify dataset type

### DIFF
--- a/entity-api-spec.yaml
+++ b/entity-api-spec.yaml
@@ -1448,7 +1448,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  dataset_uuid:
+                  uuid:
                     type: string
                     description: The uuid of a dataset
                   revision_number:

--- a/src/app.py
+++ b/src/app.py
@@ -2075,6 +2075,7 @@ Returns
 list
     The list of revision datasets
 """
+@app.route('/entities/<id>/revisions', methods=['GET'])
 @app.route('/datasets/<id>/revisions', methods=['GET'])
 def get_revisions_list(id):
     # By default, do not return dataset. Only return dataset if return_dataset is true
@@ -2097,7 +2098,7 @@ def get_revisions_list(id):
 
     # Only for Dataset
     if normalized_entity_type != 'Dataset':
-        bad_request_error("The entity of given id is not a Dataset")
+        bad_request_error("The entity is not a Dataset. Found entity type:" + normalized_entity_type)
 
     # Only published/public datasets don't require token
     if entity_dict['status'].lower() != DATASET_STATUS_PUBLISHED:

--- a/src/app.py
+++ b/src/app.py
@@ -2137,7 +2137,7 @@ def get_revisions_list(id):
     for revision in normalized_revisions_list:
         result = {
             'revision_number': revision_number,
-            'dataset_uuid': revision['uuid']
+            'uuid': revision['uuid']
         }
         if show_dataset:
             result['dataset'] = revision


### PR DESCRIPTION
Per request from John Conroy:
  - change output to use `uuid` instead of `dataset_uuid`
  - provide a second, not specific dataset route `/entities/<id>/revisions`