### PR TITLE
modified the way data types are partsed for get_sankey_data in neo4jq…

### DIFF
--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -1166,10 +1166,14 @@ def get_sankey_info(neo4j_driver):
                 record_contents.append(item)
             record_dict['dataset_group_name'] = record_contents[0]
             record_dict['organ_type'] = record_contents[1]
-            data_types = record_contents[2]
-            data_types = data_types.replace("'", '"')
-            data_types = json.loads(data_types)
-            record_dict['dataset_data_types'] = ",".join(data_types)
+            data_types_list = record_contents[2]
+            data_types_list = data_types_list.replace("'", '"')
+            data_types_list = json.loads(data_types_list)
+            data_types = data_types_list[0]
+            if (len(data_types_list)) > 1:
+                if (data_types_list[0] == "scRNAseq-10xGenomics-v3" and data_types_list[1] == "snATACseq") or (data_types_list[1] == "scRNAseq-10xGenomics-v3" and data_types_list[0] == "snATACseq"):
+                    data_types = "scRNA-seq (10x Genomics v3),snATAC-seq"
+            record_dict['dataset_data_types'] = data_types
             record_dict['dataset_status'] = record_contents[3]
             list_of_dictionaries.append(record_dict)
         return list_of_dictionaries


### PR DESCRIPTION
modified the way data types are partsed for get_sankey_data in neo4jqueries
There's a specific edge case we're accommodating but otherwise, we always
want the first element in the data_types array to be returned.