### PR TITLE
Derek furst/dbgapurl

### DIFF
--- a/entity-api-spec.yaml
+++ b/entity-api-spec.yaml
@@ -783,6 +783,15 @@ components:
           type: string
           format: file_uuid
           description: 'The thumbnail image file previously uploaded to delete. Provide as a string of the file_uuid like: "c35002f9c3d49f8b77e1e2cd4a01803d"'
+        sub_status:
+          type: string
+          description: 'A sub-status provided to further define the status. The only current allowable value is "Retracted"'
+        retraction_reason:
+          type: string
+          description: 'Information recorded about why a the dataset was retracted.'
+        dbgap_url:
+          type: string
+          description: 'A URL linking the dataset to the associated uploaded data at dbGaP.'
     Upload:
       type: object
       properties:

--- a/src/app.py
+++ b/src/app.py
@@ -1075,6 +1075,16 @@ def update_entity(id):
     # Parse incoming json string into json data(python dict object)
     json_data_dict = request.get_json()
 
+    # Normalize user provided status
+    if "status" in json_data_dict:
+        normalized_status = schema_manager.normalize_status(json_data_dict["status"])
+        json_data_dict["status"] = normalized_status
+
+    # Normalize user provided status
+    if "sub_status" in json_data_dict:
+        normalized_status = schema_manager.normalize_status(json_data_dict["sub_status"])
+        json_data_dict["sub_status"] = normalized_status
+
     # Get target entity and return as a dict if exists
     entity_dict = query_target_entity(id, user_token)
 
@@ -2126,6 +2136,11 @@ def retract_dataset(id):
 
     # Parse incoming json string into json data(python dict object)
     json_data_dict = request.get_json()
+
+    # Normalize user provided status
+    if "sub_status" in json_data_dict:
+        normalized_status = schema_manager.normalize_status(json_data_dict["sub_status"])
+        json_data_dict["sub_status"] = normalized_status
 
     # Use beblow application-level validations to avoid complicating schema validators
     # The 'retraction_reason' and `sub_status` are the only required/allowed fields. No other fields allowed.

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -247,7 +247,6 @@ ENTITIES:
         immutable: true # Disallow update via PUT
         description: "The auto generated dataset title."
         on_read_trigger: get_dataset_title
-        description: "The auto generated dataset title."
       lab_dataset_id:
         type: string
         description: "A name or identifier used by the lab who is uploading the data to cross reference the data locally"
@@ -404,6 +403,9 @@ ENTITIES:
       provider_info:
         type: string
         description: 'Information recorded about the data provider before an analysis pipeline is run on the data.'
+      dbgap_url:
+        type: string
+        description: 'A URL linking the dataset to the associated uploaded data at dbGaP.'
 
   ############################################# Donor #############################################
   Donor:

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -824,6 +824,26 @@ def normalize_entity_type(entity_type):
     return normalized_entity_type
 
 """
+Lowercase and capitalize the status string unless its "qa", then make it capitalized.
+
+Parameters
+----------
+status : str
+    One of the status types: New|Processing|QA|Published|Error|Hold|Invalid
+    
+Returns
+-------
+string
+    One of the normalized status types: New|Processing|QA|Published|Error|Hold|Invalid
+"""
+def normalize_status(status):
+    if status.lower() == "qa":
+        normalized_status = "QA"
+    else:
+        normalized_status = status.lower().capitalize()
+    return normalized_status
+
+"""
 Validate the provided trigger type
 
 Parameters


### PR DESCRIPTION
@yuanzhou This adds dbgap_url to the provenance schema as well as the entity api spec schema. I also took the liberty of adding sub status and retraction reason to the entity api spec because they weren't put there yet. Additionally, I noticed that there was a duplicate description inside an existing property in the api spec so I removed it. 

Looking at the compare/diff screen, it looks as though this merge will add the capitalization changes for some reason so those must not have existed on dev-integrate somehow. I created this branch off of main. 