### PR TITLE
Added db_gap url to provenance schema. Added db_gap to entity api spec.

### DIFF
--- a/entity-api-spec.yaml
+++ b/entity-api-spec.yaml
@@ -783,6 +783,15 @@ components:
           type: string
           format: file_uuid
           description: 'The thumbnail image file previously uploaded to delete. Provide as a string of the file_uuid like: "c35002f9c3d49f8b77e1e2cd4a01803d"'
+        sub_status:
+          type: string
+          description: 'A sub-status provided to further define the status. The only current allowable value is "Retracted"'
+        retraction_reason:
+          type: string
+          description: 'Information recorded about why a the dataset was retracted.'
+        dbgap_url:
+          type: string
+          description: 'A URL linking the dataset to the associated uploaded data at dbGaP.'
     Upload:
       type: object
       properties:

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -247,7 +247,6 @@ ENTITIES:
         immutable: true # Disallow update via PUT
         description: "The auto generated dataset title."
         on_read_trigger: get_dataset_title
-        description: "The auto generated dataset title."
       lab_dataset_id:
         type: string
         description: "A name or identifier used by the lab who is uploading the data to cross reference the data locally"
@@ -404,6 +403,9 @@ ENTITIES:
       provider_info:
         type: string
         description: 'Information recorded about the data provider before an analysis pipeline is run on the data.'
+      dbgap_url:
+        type: string
+        description: 'A URL linking the dataset to the associated uploaded data at dbGaP.'
 
   ############################################# Donor #############################################
   Donor:


### PR DESCRIPTION
Added db_gap url to provenance schema. Added db_gap to entity api spec. 
Also added sub_status and retraction_reason to the api spec as they were 
missing. Removed a duplicate description in the entity api spec.