### PR TITLE
Include Samples in prov info to support files-api

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,7 @@ PyYAML==5.4.1
 # Use the branch name of commons from github for testing new changes made in commons from different branch
 # Default is main branch specified in docker-compose.development.yml if not set
 # git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
-hubmap-commons==2.1.2
+hubmap-commons==2.1.3
 
 # For unit test
 nose2==0.10.0

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1229,7 +1229,8 @@ def create_hubmap_ids(normalized_class, json_data_dict, user_token, user_info_di
     logger.info(json_to_post)
 
     # Disable ssl certificate verification
-    response = requests.post(url = _uuid_api_url, headers = request_headers, json = json_to_post, verify = False, params = query_parms) 
+    target_url = _uuid_api_url + '/uuid'
+    response = requests.post(url = target_url, headers = request_headers, json = json_to_post, verify = False, params = query_parms)
     
     # Invoke .raise_for_status(), an HTTPError will be raised with certain status codes
     response.raise_for_status()

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1068,7 +1068,7 @@ dict
 def get_hubmap_ids(id):
     global _uuid_api_url
 
-    target_url = _uuid_api_url + '/' + id
+    target_url = _uuid_api_url + '/uuid/' + id
 
     # Function cache to improve performance
     response = make_request_get(target_url, internal_token_used = True)


### PR DESCRIPTION
Include sample information with provenance info to support the files-api creating file info documents.
Form complete uuid-api call "in code" from a configured base URL, replacing a configured complete URL.