### PR TITLE
Fixed a bug caused by an "AND" where a "WHERE" should be in the optional

### DIFF
--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -962,7 +962,7 @@ def get_prov_info(neo4j_driver, param_dict, published_only):
         dataset_status_query_string = f" AND toUpper(ds.status) = '{param_dict['dataset_status'].upper()}'"
     if published_only:
         published_only_query_string = f" AND toUpper(ds.status) = 'PUBLISHED'"
-        published_only_revisions_string = f" AND toUpper(rev.status) = 'PUBLISHED'"
+        published_only_revisions_string = f" WHERE toUpper(rev.status) = 'PUBLISHED'"
     query = (f"MATCH (ds:Dataset)<-[:ACTIVITY_OUTPUT]-(a)<-[:ACTIVITY_INPUT]-(firstSample:Sample)<-[*]-(donor:Donor)"
              f"WHERE not (ds)-[:REVISION_OF]->(:Dataset)"
              f"{group_uuid_query_string}"


### PR DESCRIPTION
Fixed a bug caused by an "AND" where a "WHERE" should be in the optional
revision_of match in get_prov_info in app_neo4j_queries.py