### PR TITLE
Fixed a bug caused by trying to run a non-node object through node_to…

### DIFF
--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -1048,8 +1048,7 @@ def get_prov_info(neo4j_driver, param_dict, published_only):
             record_dict['processed_dataset'] = content_sixteen
             content_seventeen = []
             for entry in record_contents[17]:
-                node_dict = _node_to_dict(entry)
-                content_seventeen.append(node_dict)
+                content_seventeen.append(entry)
             record_dict['previous_version_hubmap_ids'] = content_seventeen
             list_of_dictionaries.append(record_dict)
     return list_of_dictionaries


### PR DESCRIPTION
…_dict.

REVISION is returned as a list of strings rather than a list of node objects like it is most everywhere else in the output of the query. Removing the conversion from a node to a dict fixed it.