### PR TITLE
Modified datasets/prov-info and samples/prov-info to check the size o…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2857,10 +2857,10 @@ def get_prov_info():
         dataset_prov_list.append(internal_dict)
 
     # Determine whether the size of the returned data exceeds or nearly exceeds the AWS Gateway 10MB maximum size. If it
-    # is greater than 9MB Return a 400 and prompt the user to reduce the size of the output by applying optional
+    # is greater than 9437184 bytes Return a 400 and prompt the user to reduce the size of the output by applying optional
     # argument filters.
     dataset_prov_json_encode = json.dumps(dataset_prov_list).encode('utf-8')
-    if len(dataset_prov_json_encode) > 9000000:
+    if len(dataset_prov_json_encode) > 9437184:
         bad_request_error(
             "Request generated a response over the 10MB limit.  Sub-select the results using a query parameter.")
 
@@ -3457,10 +3457,10 @@ def get_sample_prov_info():
         sample_prov_list.append(internal_dict)
 
     # Determine whether the size of the returned data exceeds or nearly exceeds the AWS Gateway 10MB maximum size. If it
-    # is greater than 9MB Return a 400 and prompt the user to reduce the size of the output by applying optional
+    # is greater than 9437184 bytes Return a 400 and prompt the user to reduce the size of the output by applying optional
     # argument filters.
     sample_prov_json_encode = json.dumps(sample_prov_list).encode('utf-8')
-    if len(sample_prov_json_encode) > 9000000:
+    if len(sample_prov_json_encode) > 9437184:
         bad_request_error(
             "Request generated a response over the 10MB limit.  Sub-select the results using a query parameter.")
     return jsonify(sample_prov_list)

--- a/src/app.py
+++ b/src/app.py
@@ -2688,9 +2688,9 @@ def get_prov_info():
         internal_dict[HEADER_DATASET_STATUS] = dataset['status']
         internal_dict[HEADER_DATASET_GROUP_NAME] = dataset['group_name']
         internal_dict[HEADER_DATASET_GROUP_UUID] = dataset['group_uuid']
-        internal_dict[HEADER_DATASET_DATE_TIME_CREATED] = datetime.fromtimestamp(int(dataset['created_timestamp']/1000.0))
+        internal_dict[HEADER_DATASET_DATE_TIME_CREATED] = str(datetime.fromtimestamp(int(dataset['created_timestamp'] / 1000.0)))
         internal_dict[HEADER_DATASET_CREATED_BY_EMAIL] = dataset['created_by_user_email']
-        internal_dict[HEADER_DATASET_DATE_TIME_MODIFIED] = datetime.fromtimestamp(int(dataset['last_modified_timestamp']/1000.0))
+        internal_dict[HEADER_DATASET_DATE_TIME_MODIFIED] = str(datetime.fromtimestamp(int(dataset['last_modified_timestamp'] / 1000.0)))
         internal_dict[HEADER_DATASET_MODIFIED_BY_EMAIL] = dataset['last_modified_user_email']
         internal_dict[HEADER_DATASET_LAB_ID] = dataset['lab_dataset_id']
 
@@ -2856,6 +2856,14 @@ def get_prov_info():
         # Each dataset's dictionary is added to the list to be returned
         dataset_prov_list.append(internal_dict)
 
+    # Determine whether the size of the returned data exceeds or nearly exceeds the AWS Gateway 10MB maximum size. If it
+    # is greater than 9MB Return a 400 and prompt the user to reduce the size of the output by applying optional
+    # argument filters.
+    dataset_prov_json_encode = json.dumps(dataset_prov_list).encode('utf-8')
+    if len(dataset_prov_json_encode) > 9000000:
+        bad_request_error(
+            "Request generated a response over the 10MB limit.  Sub-select the results using a query parameter.")
+
     # if return_json is true, this dictionary is ready to be returned already
     if return_json:
         return jsonify(dataset_prov_list)
@@ -3018,10 +3026,9 @@ def get_prov_info_for_dataset(id):
     internal_dict[HEADER_DATASET_STATUS] = dataset['status']
     internal_dict[HEADER_DATASET_GROUP_NAME] = dataset['group_name']
     internal_dict[HEADER_DATASET_GROUP_UUID] = dataset['group_uuid']
-    internal_dict[HEADER_DATASET_DATE_TIME_CREATED] = datetime.fromtimestamp(int(dataset['created_timestamp'] / 1000.0))
+    internal_dict[HEADER_DATASET_DATE_TIME_CREATED] = str(datetime.fromtimestamp(int(dataset['created_timestamp'] / 1000.0)))
     internal_dict[HEADER_DATASET_CREATED_BY_EMAIL] = dataset['created_by_user_email']
-    internal_dict[HEADER_DATASET_DATE_TIME_MODIFIED] = datetime.fromtimestamp(
-        int(dataset['last_modified_timestamp'] / 1000.0))
+    internal_dict[HEADER_DATASET_DATE_TIME_MODIFIED] = str(datetime.fromtimestamp(int(dataset['last_modified_timestamp'] / 1000.0)))
     internal_dict[HEADER_DATASET_MODIFIED_BY_EMAIL] = dataset['last_modified_user_email']
     internal_dict[HEADER_DATASET_LAB_ID] = dataset['lab_dataset_id']
 
@@ -3448,7 +3455,14 @@ def get_sample_prov_info():
 
         # Each sample's dictionary is added to the list to be returned
         sample_prov_list.append(internal_dict)
-        
+
+    # Determine whether the size of the returned data exceeds or nearly exceeds the AWS Gateway 10MB maximum size. If it
+    # is greater than 9MB Return a 400 and prompt the user to reduce the size of the output by applying optional
+    # argument filters.
+    sample_prov_json_encode = json.dumps(sample_prov_list).encode('utf-8')
+    if len(sample_prov_json_encode) > 9000000:
+        bad_request_error(
+            "Request generated a response over the 10MB limit.  Sub-select the results using a query parameter.")
     return jsonify(sample_prov_list)
 
 


### PR DESCRIPTION
Modified datasets/prov-info and samples/prov-info to check the size of the 
returned json before returning. If it is at (or near) the max for AWS, 
return a 400 prompting the user to apply some optional parameters to reduce
the size. Changed the date values in datasets/prov-info and 
datasets/<id>/prov-info by converting them to strings from datetime
objects. While they were datetime objects, they weren't valid json, so 
dumping to json would result in a 500.