### PR TITLE
Add after_update() trigger logic for Collections to handle dataset_uuids

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1402,6 +1402,12 @@ def update_entity(id):
         # Handle linkages update via `after_update_trigger` methods
         if has_dataset_uuids_to_link or has_dataset_uuids_to_unlink:
             after_update(normalized_entity_type, user_token, merged_updated_dict)
+    elif normalized_entity_type == 'Collection':
+        # Generate 'before_update_trigger' data and update the entity details in Neo4j
+        merged_updated_dict = update_entity_details(request, normalized_entity_type, user_token, json_data_dict, entity_dict)
+
+        # Handle linkages update via `after_update_trigger` methods
+        after_update(normalized_entity_type, user_token, merged_updated_dict)
     else:
         # Generate 'before_update_trigger' data and update the entity details in Neo4j
         merged_updated_dict = update_entity_details(request, normalized_entity_type, user_token, json_data_dict, entity_dict)


### PR DESCRIPTION
Added logic for processing the `dataset_uuids` field of a `PUT` request via trigger logic, fixing defect noted in which Collection Dataset members cannot be updated. Removed

Remove support for `/collections/<collection_uuid>/add-datasets` route.
Remove `app.py` `add_datasets_to_collection()`.
Remove `app_neo4j_queries.py` `add_datasets_to_collection()`.