### PR TITLE
Derek furst/add creation action

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4126,7 +4126,6 @@ def create_entity_details(request, normalized_entity_type, user_token, json_data
     # Meaning the returned target property key is different from the original key
     # in the trigger method, e.g., Donor.image_files_to_add
     filtered_merged_dict = schema_manager.remove_transient_and_none_values(merged_dict, normalized_entity_type)
-
     # Create new entity
     try:
         # Check if the optional `superclass` property is defined, None otherwise

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -280,7 +280,10 @@ ENTITIES:
       creation_action:
         type: string
         transient: true
+        immutable: true
         description: "The activity that was performed."
+        before_property_create_validators:
+          - validate_creation_action
       description:
         type: string
         description: "Free text description of the dataset"
@@ -513,6 +516,7 @@ ENTITIES:
       creation_action:
         type: string
         transient: true
+        immutable: true
         description: "The activity that was performed."
         before_property_create_validators:
           - validate_creation_action

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -88,8 +88,6 @@ ACTIVITIES:
       <<: *shared_properties
       creation_action:
         type: string
-        generated: true
-        immutable: true
         description: "The activity that was performed."
         before_create_trigger: set_activity_creation_action
 
@@ -279,6 +277,10 @@ ENTITIES:
       antibodies:
         type: list
         description: "A list of antibodies used in the assay that created the dataset"
+      creation_action:
+        type: string
+        transient: true
+        description: "The activity that was performed."
       description:
         type: string
         description: "Free text description of the dataset"
@@ -508,6 +510,12 @@ ENTITIES:
         type: string
         description: "Additional information about the dataset, which can be used to find this dataset, including lab specific (non-PHI) identifiers."
       # The Dataset.data_access_level is based on Dataset.status and Dataset.contains_human_genetic_sequences
+      creation_action:
+        type: string
+        transient: true
+        description: "The activity that was performed."
+        before_property_create_validators:
+          - validate_creation_action
       data_access_level:
         type: string
         generated: true

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1907,7 +1907,8 @@ str: The creation_action string
 def set_activity_creation_action(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
     if 'normalized_entity_type' not in new_data_dict:
         raise KeyError("Missing 'normalized_entity_type' key in 'existing_data_dict' during calling 'set_activity_creation_action()' trigger method.")
-    
+    if new_data_dict and new_data_dict['creation_action']:
+        return property_key, new_data_dict['creation_action']
     return property_key, f"Create {new_data_dict['normalized_entity_type']} Activity"
 
 

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1907,8 +1907,8 @@ str: The creation_action string
 def set_activity_creation_action(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
     if 'normalized_entity_type' not in new_data_dict:
         raise KeyError("Missing 'normalized_entity_type' key in 'existing_data_dict' during calling 'set_activity_creation_action()' trigger method.")
-    if new_data_dict and new_data_dict['creation_action']:
-        return property_key, new_data_dict['creation_action']
+    if new_data_dict and new_data_dict.get('creation_action'):
+        return property_key, new_data_dict['creation_action'].title()
     return property_key, f"Create {new_data_dict['normalized_entity_type']} Activity"
 
 

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -527,7 +527,7 @@ new_data_dict : dict
 """
 def validate_creation_action(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
     creation_action = new_data_dict[property_key]
-    if creation_action and creation_action not in ["HIVE Process", "Lab Process"]:
+    if creation_action and creation_action not in ["Central Process", "Lab Process", "Multi-Assay Split"]:
         raise ValueError(f"Invalid {property_key} value")
 
 

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -526,9 +526,12 @@ new_data_dict : dict
     The json data in request body, already after the regular validations
 """
 def validate_creation_action(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
-    creation_action = new_data_dict[property_key]
-    if creation_action and creation_action not in ["Central Process", "Lab Process", "Multi-Assay Split"]:
-        raise ValueError(f"Invalid {property_key} value")
+    accepted_creation_action_values = ["central process", "lab process", "multi-assay split"]
+    creation_action = new_data_dict[property_key].lower()
+    if creation_action and creation_action not in accepted_creation_action_values:
+        raise ValueError("Invalid {} value. Accepted values are: {}".format(property_key, ", ".join(accepted_creation_action_values)))
+    if creation_action == '':
+        raise ValueError(f"The property {property_key} cannot be empty, when specified.")
 
 
 ####################################################################################################

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -509,6 +509,27 @@ def validate_publication_date(property_key, normalized_entity_type, request, exi
     except ValueError:
         raise ValueError(f"Invalid {property_key} format, must be YYYY-MM-DD")
 
+"""
+Validate the provided value of the activity creation action. Only very specific
+values are allowed.
+Parameters
+----------
+property_key : str
+    The target property key
+normalized_type : str
+    Submission
+request: Flask request object
+    The instance of Flask request passed in from application request
+existing_data_dict : dict
+    A dictionary that contains all existing entity properties
+new_data_dict : dict
+    The json data in request body, already after the regular validations
+"""
+def validate_creation_action(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
+    creation_action = new_data_dict[property_key]
+    if creation_action and creation_action not in ["HIVE Process", "Lab Process"]:
+        raise ValueError(f"Invalid {property_key} value")
+
 
 ####################################################################################################
 ## Internal Functions


### PR DESCRIPTION
Added property creation_action to datasets and publications. This property is transient and immutable, so it won't be saved in the
database within the dataset/publication node itself, however the trigger method for the activity node with this property has been updated to grab this value if its in the json. If this field isn't present, it defaults to the existing value. Validator verifies that the property is only 'Central Process', 'Lab Process', or 'Multi-assay Split'. 