### PR TITLE
Automatically set dataset_type on Publication entities

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -602,12 +602,14 @@ ENTITIES:
         required_on_create: false
         description: "The data or assay types contained in this dataset as a json array of strings.  Each is an assay code from [assay types](https://github.com/hubmapconsortium/search-api/blob/main/src/search-schema/data/definitions/enums/assay_types.yaml)."
       dataset_type:
+        before_create_trigger: set_publication_dataset_type
         before_property_create_validators:
           - validate_recognized_dataset_type
         before_property_update_validators:
           - validate_recognized_dataset_type
         type: string
-        required_on_create: true #Required for create via POST, not update via PUT
+        generated: true
+        immutable: true
         description: "The assay types of this Dataset. Valid values are from UBKG are queried by schema_manager.get_valueset_dataset_type() using the Ontology API."
       collections:
         type: list

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1681,6 +1681,31 @@ def set_publication_date(property_key, normalized_type, user_token, existing_dat
 
     return property_key, date_obj.date().isoformat()
 
+"""
+Trigger event method setting the dataset_type immutable property for a Publication.
+
+Parameters
+----------
+property_key : str
+    The target property key of the value to be generated
+normalized_type : str
+    One of the types defined in the schema yaml: Publication
+user_token: str
+    The user's globus nexus token
+existing_data_dict : dict
+    A dictionary that contains all existing entity properties
+new_data_dict : dict
+    A merged dictionary that contains all possible input data to be used
+
+Returns
+-------
+str: The target property key
+str: Immutable dataset_type of "Publication"
+"""
+def set_publication_dataset_type(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+    # Count upon the dataset_type generated: true property in provenance_schema.yaml to assure the
+    # request does not contain a value which will be overwritten.
+    return property_key, 'Publication'
 
 ####################################################################################################
 ## Trigger methods specific to Upload - DO NOT RENAME


### PR DESCRIPTION
Generate dataset_type='Publication' for Publication entities, and prohibit dataset_type from being specified on the request.