### PR TITLE
Derek furst/sync component datasets

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,26 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+on:
+  push:
+    branches: [ "main", "dev-integrate" ]
+  pull_request:
+    branches: [ "main", "dev-integrate" ]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Upgrade Pip
+      run: python -m pip install --upgrade pip
+      working-directory: src
+    - name: Install Dependencies
+      run: pip install -r requirements.txt
+      working-directory: src

--- a/src/app.py
+++ b/src/app.py
@@ -204,6 +204,7 @@ try:
                               app.config['UUID_API_URL'],
                               app.config['INGEST_API_URL'],
                               app.config['ONTOLOGY_API_URL'],
+                              app.config['ENTITY_API_URL'],
                               auth_helper_instance,
                               neo4j_driver_instance,
                               memcached_client_instance,

--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -32,6 +32,9 @@ INGEST_API_URL = 'https://ingest-api.dev.hubmapconsortium.org'
 # Works regardless of the trailing slash
 ONTOLOGY_API_URL = 'https://ontology-api.dev.hubmapconsortium.org'
 
+# URL for talking to Entity API (default for DEV)
+ENTITY_API_URL = 'https://entity-api.dev.hubmapconsortium.org'
+
 # A list of URLs for talking to multiple Search API instances (default value used for docker deployment, no token needed)
 # Works regardless of the trailing slash /
 SEARCH_API_URL_LIST = ['http://search-api:8080']

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -311,11 +311,12 @@ ENTITIES:
           - validate_application_header_before_property_update
           - validate_dataset_status_value
           - validate_status_changed
+          - validate_dataset_not_component
         generated: true
         description: "One of: New|Processing|Published|QA|Error|Hold|Invalid|Submitted|Incomplete"
         before_create_trigger: set_dataset_status_new
         after_create_trigger: set_status_history
-        after_update_trigger: set_status_history
+        after_update_trigger: update_status
       title:
         type: string
         generated: true # Disallow entry from users via POST

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -3,7 +3,7 @@
 # - type: data type of the property, one of the following: string|integer|boolean|list|json_string
 # - generated: whether the property is auto generated (either with a  `before_create_trigger` or not) or user provided, default to false
 # - required_on_create: whether the property is required from user reqeust JSON for entity creation via POST
-# - immutable: whether the property can NOT be updated once being created, default to false
+# - immutable: true indicates the property can NOT be updated after the entity is created, default to false
 # - transient: whether the property to persist in database or not, default to false
 # - exposed: whether the property gets returned to the user or not, default to true
 # - trigger types: before_create_trigger|after_create_trigger|before_update_trigger|after_update_trigger|on_read_trigger, one property can have none (default) or more than one triggers
@@ -457,6 +457,28 @@ ENTITIES:
         immutable: true
         description: "The list of the uuids of next revision datasets"
         on_read_trigger: get_next_revision_uuids
+      superseded_associated_processed_component_uuids:
+        type: list
+        # This property gets set via a PUT by entity-api /entities/{{dataset_uuid}} to point to the Multi-Assay Dataset
+        # superseding the entity with this attribute, so we can't define it as `immutable: true`.
+        # Modifications to an existing attribute are rejected using a validation trigger.
+        immutable: false
+        description: "List of uuids of existing Datasets used to construct this Multi-Assay Dataset, when present"
+        before_property_create_validators:
+          - verify_multi_assay_dataset_components
+        before_property_update_validators:
+          - verify_multi_assay_dataset_components
+      new_associated_multi_assay_uuid:
+        type: string
+        # This property gets set via a PUT by entity-api /entities/{{dataset_uuid}} to point to the Multi-Assay Dataset
+        # superseding the entity with this attribute, so we can't define it as `immutable: true`.
+        # Modifications to an existing attribute are rejected using a validation trigger.
+        immutable: false
+        description: "The uuid of the Multi-Assay Dataset constructed using this Dataset, when present"
+        before_property_create_validators:
+          - verify_multi_assay_dataset_components
+        before_property_update_validators:
+          - verify_multi_assay_dataset_components
       # No like image and metadata files handling for Donor/Sample
       # Dataset has only one thumbnail file
       thumbnail_file:
@@ -609,6 +631,8 @@ ENTITIES:
         after_update_trigger: link_publication_to_associated_collection
       assigned_to_group_name: null # This assigned_to_group_name is Dataset specific, Publication doesn't have it
       ingest_task: null # This ingest_task is Dataset specific, Publication doesn't have it
+      new_associated_multi_assay_uuid: null # Dataset-only attribute of Multi-Assay Dataset relationships
+      superseded_associated_processed_component_uuids: null # Dataset-only attribute of Multi-Assay Dataset relationships
 
   ############################################# Donor #############################################
   Donor:

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -312,7 +312,7 @@ ENTITIES:
           - validate_dataset_status_value
           - validate_status_changed
         generated: true
-        description: "One of: New|Processing|QA|Published|Error|Hold|Invalid|Submitted"
+        description: "One of: New|Processing|Published|QA|Error|Hold|Invalid|Submitted|Incomplete"
         before_create_trigger: set_dataset_status_new
         after_create_trigger: set_status_history
         after_update_trigger: set_status_history
@@ -931,7 +931,7 @@ ENTITIES:
           - validate_status_changed
         type: string
         generated: true
-        description: "One of: New|Valid|Invalid|Error|Reorganized|Processing"
+        description: "One of: New|Valid|Invalid|Error|Reorganized|Processing|Submitted|Incomplete"
         # Trigger method will set the status to "New" on create
         before_create_trigger: set_upload_status_new
         after_create_trigger: set_status_history

--- a/src/schema/schema_constants.py
+++ b/src/schema/schema_constants.py
@@ -11,6 +11,7 @@ class SchemaConstants(object):
     ACCESS_LEVEL_CONSORTIUM = 'consortium'
     ACCESS_LEVEL_PROTECTED = 'protected'
 
+    ENTITY_API_UPDATE_ENDPOINT = '/entities'
     UUID_API_ID_ENDPOINT = '/uuid'
     INGEST_API_FILE_COMMIT_ENDPOINT = '/file-commit'
     INGEST_API_FILE_REMOVE_ENDPOINT = '/file-remove'

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -534,7 +534,7 @@ token : string
 def update_entity(uuid, data, token):
     url = _entity_api_url + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT +  '/' + uuid
     header = _create_request_headers(token)
-    header['X-Hubmap-Application'] = 'ingest-api'
+    header[schemaConstants.HUBMAP_APP_HEADER] = INGEST_API_APP
     response = requests.put(url=url, headers=header, json=data)
 """
 Generate the complete entity record by running the read triggers

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 import yaml
 import logging
 import requests

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -517,25 +517,6 @@ def remove_transient_and_none_values(merged_dict, normalized_entity_type):
 
 
 """
-Update entity via HTTP call to entity-api
-This is useful when a change in one entity necessitates changes in another, while allowing the normal triggers
-and validators to execute
-
-Parameters
-----------
-uuid : string
-    The uuid of the entity being updated
-data : dict
-    A dict representation of the json_data_dict for the updated entity
-token : string
-    The globus groups token
-"""
-def update_entity(uuid, data, token):
-    url = _entity_api_url + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT +  '/' + uuid
-    header = _create_request_headers(token)
-    header[schemaConstants.HUBMAP_APP_HEADER] = INGEST_API_APP
-    response = requests.put(url=url, headers=header, json=data)
-"""
 Generate the complete entity record by running the read triggers
 
 Parameters
@@ -1727,6 +1708,22 @@ def get_ingest_api_url():
     global _ingest_api_url
     
     return _ingest_api_url
+
+
+"""
+Get the entity-api URL to be used by trigger methods
+
+Returns
+-------
+str
+    The entity-api URL
+"""
+
+
+def get_entity_api_url():
+    global _entity_api_url
+
+    return _entity_api_url
 
 
 """

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1456,6 +1456,10 @@ def sync_component_dataset_status(property_key, normalized_type, user_token, exi
         creation_action = schema_neo4j_queries.get_entity_creation_action_activity(schema_manager.get_neo4j_driver_instance(), child_uuid)
         if creation_action == 'Multi-Assay Split':
             schema_manager.update_entity(child_uuid, status_body, user_token)
+            url = schema_manager.get_entity_api_url + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT + '/' + child_uuid
+            header = _create_request_headers(user_token)
+            header[schemaConstants.HUBMAP_APP_HEADER] = schemaConstants.INGEST_API_APP
+            response = requests.put(url=url, headers=header, json=status_body)
 
 
 ####################################################################################################

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1455,10 +1455,9 @@ def sync_component_dataset_status(property_key, normalized_type, user_token, exi
     for child_uuid in children_uuids_list:
         creation_action = schema_neo4j_queries.get_entity_creation_action_activity(schema_manager.get_neo4j_driver_instance(), child_uuid)
         if creation_action == 'Multi-Assay Split':
-            schema_manager.update_entity(child_uuid, status_body, user_token)
-            url = schema_manager.get_entity_api_url + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT + '/' + child_uuid
-            header = _create_request_headers(user_token)
-            header[schemaConstants.HUBMAP_APP_HEADER] = schemaConstants.INGEST_API_APP
+            url = schema_manager.get_entity_api_url() + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT + '/' + child_uuid
+            header = schema_manager._create_request_headers(user_token)
+            header[SchemaConstants.HUBMAP_APP_HEADER] = SchemaConstants.INGEST_API_APP
             response = requests.put(url=url, headers=header, json=status_body)
 
 

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -46,7 +46,6 @@ def validate_application_header_before_entity_create(normalized_entity_type, req
 
 
 """
-@TODO-KBKBKB redo doc...
 Validate the specified value for a Dataset's dataset_type is in the valueset UBKG recognizes. 
 
 Parameters
@@ -630,6 +629,72 @@ def validate_group_name(property_key, normalized_entity_type, request, existing_
         raise ValueError("Invalid group in 'assigned_to_group_name'. Must be a data provider")
 
 
+"""
+Trigger event method to verify tracking fields new_associated_multi_assay_uuid and
+superseded_associated_processed_component_uuids are set coherently on Multi-Assay Datasets and
+their component Datasets.
+
+Parameters
+----------
+property_key : str
+    The target property key
+normalized_type : str
+    One of the types defined in the schema yaml: Dataset
+user_token: str
+    The user's globus nexus token
+existing_data_dict : dict
+    A dictionary that contains all existing entity properties as Neo4j data types.
+    N.B. elements are not Python data types and must be converted with utilities like schema_manager.convert_str_literal()
+new_data_dict : dict
+    The request input data as Python data structures converted from JSON, which has passed schema validation, entity
+    validation, and possibly other property validations.
+"""
+
+def verify_multi_assay_dataset_components(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
+
+    if  'superseded_associated_processed_component_uuids' in existing_data_dict \
+        and 'superseded_associated_processed_component_uuids' in new_data_dict:
+        raise ValueError(   f"'superseded_associated_processed_component_uuids' is already set on"
+                            f" {existing_data_dict['uuid']}.")
+    if  'new_associated_multi_assay_uuid' in existing_data_dict \
+        and 'new_associated_multi_assay_uuid' in new_data_dict:
+        raise ValueError(   f"'new_associated_multi_assay_uuid' is already set on"
+                            f" {existing_data_dict['uuid']}.")
+    if  'superseded_associated_processed_component_uuids' in new_data_dict \
+        and 'new_associated_multi_assay_uuid' in new_data_dict:
+        raise ValueError(   f"'superseded_associated_processed_component_uuids' and 'new_associated_multi_assay_uuid'"
+                            f" cannot both be specified on a single Dataset.")
+    if  'superseded_associated_processed_component_uuids' in new_data_dict \
+        and 'new_associated_multi_assay_uuid' in existing_data_dict:
+        raise ValueError( f"'superseded_associated_processed_component_uuids' cannot be set on"
+                        f" existing Dataset {existing_data_dict['uuid']} because it is a component Dataset of"
+                        f" {existing_data_dict['new_associated_multi_assay_uuid']}.")
+    if  'new_associated_multi_assay_uuid' in new_data_dict \
+        and 'superseded_associated_processed_component_uuids' in existing_data_dict:
+        # Convert the string from Neo4j the Python list
+        supersededComponentDatasets = schema_manager.convert_str_literal(existing_data_dict['superseded_associated_processed_component_uuids'])
+        raise ValueError( f"'new_associated_multi_assay_uuid' cannot be set on"
+                        f" existing Dataset {existing_data_dict['uuid']} because it is a Multi-Assay Dataset"
+                        f" with {len(supersededComponentDatasets)}"
+                        f" component Datasets it supersedes.")
+    # If no contradictions above have caused a ValueError, check if new data contains UUIDs for valid entities.
+    if  'new_associated_multi_assay_uuid' in new_data_dict:
+        proposedMultiAssayDataset = schema_neo4j_queries.get_entity(schema_manager.get_neo4j_driver_instance()
+                                                                    , new_data_dict['new_associated_multi_assay_uuid'])
+        if len(proposedMultiAssayDataset) < 1:
+            raise ValueError(   f"'new_associated_multi_assay_uuid' value"
+                                f" {new_data_dict['new_associated_multi_assay_uuid']}"
+                                f" does not exist.")
+    if  'superseded_associated_processed_component_uuids' in new_data_dict:
+        for uuid in new_data_dict['superseded_associated_processed_component_uuids']:
+            proposedComponentDataset = schema_neo4j_queries.get_entity( schema_manager.get_neo4j_driver_instance()
+                                                                        , uuid)
+            if len(proposedComponentDataset) < 1:
+                raise ValueError(f"'superseded_associated_processed_component_uuids' entry with value"
+                                 f" {uuid} does not exist.")
+
+    # fall out successfully if no raise() occurred.
+    return
 
 ####################################################################################################
 ## Internal Functions

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -95,6 +95,36 @@ def validate_no_duplicates_in_list(property_key, normalized_entity_type, request
     if len(set(target_list)) != len(target_list):
         raise ValueError(f"The {property_key} field must only contain unique items")
 
+
+"""
+Validate that a given dataset is not a component of a multi-assay split parent dataset fore allowing status to be 
+updated. If a component dataset needs to be updated, update it via its parent multi-assay dataset
+
+Parameters
+----------
+property_key : str
+    The target property key
+normalized_type : str
+    Submission
+request: Flask request object
+    The instance of Flask request passed in from application request
+existing_data_dict : dict
+    A dictionary that contains all existing entity properties
+new_data_dict : dict
+    The json data in request body, already after the regular validations
+"""
+
+
+def validate_dataset_not_component(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
+    neo4j_driver_instance = schema_manager.get_neo4j_driver_instance()
+    uuid = existing_data_dict['uuid']
+    creation_action = schema_neo4j_queries.get_entity_creation_action_activity(neo4j_driver_instance, uuid)
+    if creation_action == 'Multi-Assay Split':
+        raise ValueError(f"Unable to modify existing {existing_data_dict['entity_type']}"
+                         f" {existing_data_dict['uuid']}. Can not change status on component datasets directly. Status"
+                         f"change must occur on parent multi-assay split dataset")
+
+
 """
 If an entity has a DOI, do not allow it to be updated 
 """

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -280,7 +280,9 @@ new_data_dict : dict
 """
 def validate_dataset_status_value(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
     # Use lowercase for comparison
-    accepted_status_values = ['new', 'processing', 'published', 'qa', 'error', 'hold', 'invalid', 'submitted']
+    accepted_status_values = [
+        'new', 'processing', 'published', 'qa', 'error', 'hold', 'invalid', 'submitted', 'incomplete'
+    ]
     new_status = new_data_dict[property_key].lower()
 
     if new_status not in accepted_status_values:
@@ -456,7 +458,9 @@ new_data_dict : dict
 """
 def validate_upload_status_value(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
     # Use lowercase for comparison
-    accepted_status_values = ['new', 'valid', 'invalid', 'error', 'reorganized', 'processing', 'submitted']
+    accepted_status_values = [
+        'new', 'valid', 'invalid', 'error', 'reorganized', 'processing', 'submitted', 'incomplete'
+    ]
     new_status = new_data_dict[property_key].lower()
 
     if new_status not in accepted_status_values:
@@ -481,7 +485,7 @@ new_data_dict : dict
 """
 def validate_sample_category(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
     defined_tissue_types = ["organ", "block", "section", "suspension"]
-    sample_category = new_data_dict[property_key]
+    sample_category = new_data_dict[property_key].lower()
 
     if sample_category not in defined_tissue_types:
         raise ValueError(f"Invalid sample_category: {sample_category}")


### PR DESCRIPTION
Changed the status property in provenance schema yaml. Now, its after update trigger method is update_status, which calls set status history, and then calls a new function sync_component_dataset_status. this works by creating new PUT calls to entity on each of the component datasets, updating their status to whatever the multi-assay dataset was. A new validator was also created that disallows directly updating the status of component datasets. 