### PR TITLE
Added internal trigger header so that the validator

### DIFF
--- a/src/schema/schema_constants.py
+++ b/src/schema/schema_constants.py
@@ -3,8 +3,10 @@ class SchemaConstants(object):
     MEMCACHED_TTL = 7200
 
     INGEST_API_APP = 'ingest-api'
+    COMPONENT_DATASET = 'component-dataset'
     INGEST_PIPELINE_APP = 'ingest-pipeline'
     HUBMAP_APP_HEADER = 'X-Hubmap-Application'
+    INTERNAL_TRIGGER = 'X-Internal-Trigger'
     DATASET_STATUS_PUBLISHED = 'published'
 
     ACCESS_LEVEL_PUBLIC = 'public'

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1458,6 +1458,7 @@ def sync_component_dataset_status(property_key, normalized_type, user_token, exi
             url = schema_manager.get_entity_api_url() + SchemaConstants.ENTITY_API_UPDATE_ENDPOINT + '/' + child_uuid
             header = schema_manager._create_request_headers(user_token)
             header[SchemaConstants.HUBMAP_APP_HEADER] = SchemaConstants.INGEST_API_APP
+            header[SchemaConstants.INTERNAL_TRIGGER] = SchemaConstants.COMPONENT_DATASET
             response = requests.put(url=url, headers=header, json=status_body)
 
 

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -116,13 +116,15 @@ new_data_dict : dict
 
 
 def validate_dataset_not_component(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
-    neo4j_driver_instance = schema_manager.get_neo4j_driver_instance()
-    uuid = existing_data_dict['uuid']
-    creation_action = schema_neo4j_queries.get_entity_creation_action_activity(neo4j_driver_instance, uuid)
-    if creation_action == 'Multi-Assay Split':
-        raise ValueError(f"Unable to modify existing {existing_data_dict['entity_type']}"
-                         f" {existing_data_dict['uuid']}. Can not change status on component datasets directly. Status"
-                         f"change must occur on parent multi-assay split dataset")
+    headers = request.headers
+    if not headers.get(SchemaConstants.INTERNAL_TRIGGER) == SchemaConstants.COMPONENT_DATASET:
+        neo4j_driver_instance = schema_manager.get_neo4j_driver_instance()
+        uuid = existing_data_dict['uuid']
+        creation_action = schema_neo4j_queries.get_entity_creation_action_activity(neo4j_driver_instance, uuid)
+        if creation_action == 'Multi-Assay Split':
+            raise ValueError(f"Unable to modify existing {existing_data_dict['entity_type']}"
+                             f" {existing_data_dict['uuid']}. Can not change status on component datasets directly. Status"
+                             f"change must occur on parent multi-assay split dataset")
 
 
 """


### PR DESCRIPTION
Added internal trigger header so that the validator for updating datasets can be bypassed for component datasets when their update is subsequent to an update of their parent multi-assay split dataset.