### PR TITLE
Disabled multiple revisions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1028,11 +1028,9 @@ def create_entity(entity_type):
         # Also check existence of the previous revision dataset if specified
         if 'previous_revision_uuid' in json_data_dict:
             if isinstance(json_data_dict['previous_revision_uuid'], list):
+                if len(json_data_dict['previous_revision_uuid']) > 1:
+                    bad_request_error(f"Multiple previous revision uuids were provided. Only one is allowed")
                 previous_revision_list = json_data_dict['previous_revision_uuid']
-
-                nested_revisions =  app_neo4j_queries.nested_previous_revisions(neo4j_driver_instance, previous_revision_list)
-                if nested_revisions:
-                    bad_request_error(f"{nested_revisions[0][0]} is a revision of {nested_revisions[1][0]}. Datasets in previous_revision_uuid must not be revisions of eachother")
             else:
                 previous_revision_list = [json_data_dict['previous_revision_uuid']]
             for previous_revision in previous_revision_list:
@@ -1860,9 +1858,7 @@ def get_siblings(id):
         'previous_revision_uuid',
         'associated_collection',
         'creation_action',
-        'local_directory_rel_path',
-        'previous_revision_uuids',
-        'next_revision_uuids'
+        'local_directory_rel_path'
     ]
 
     complete_entities_list = schema_manager.get_complete_entities_list(token, sibling_list, properties_to_skip)
@@ -1966,9 +1962,7 @@ def get_tuplets(id):
         'previous_revision_uuid',
         'associated_collection',
         'creation_action',
-        'local_directory_rel_path',
-        'previous_revision_uuids',
-        'next_revision-uuids'
+        'local_directory_rel_path'
     ]
 
     complete_entities_list = schema_manager.get_complete_entities_list(token, tuplet_list, properties_to_skip)
@@ -2441,97 +2435,97 @@ def get_dataset_revision_number(id):
     return jsonify(revision_number)
 
 
-"""
-Retrieve a list of all multi revisions of a dataset from the id of any dataset in the chain. 
-E.g: If there are 5 revisions, and the id for revision 4 is given, a list of revisions
-1-5 will be returned in reverse order (newest first). Non-public access is only required to 
-retrieve information on non-published datasets. Output will be a list of dictionaries. Each dictionary
-contains the dataset revision number and its list of uuids. Optionally, the full dataset can be included for each.
-
-By default, only the revision number and uuids are included. To include the full dataset, the query 
-parameter "include_dataset" can be given with the value of "true". If this parameter is not included or 
-is set to false, the dataset will not be included. For example, to include the full datasets for each revision,
-use '/datasets/<id>/multi-revisions?include_dataset=true'. To omit the datasets, either set include_dataset=false, or
-simply do not include this parameter. 
-
-Parameters
-----------
-id : str
-    The HuBMAP ID (e.g. HBM123.ABCD.456) or UUID of target dataset 
-
-Returns
--------
-list
-    The list of revision datasets
-"""
-@app.route('/entities/<id>/multi-revisions', methods=['GET'])
-@app.route('/datasets/<id>/multi-revisions', methods=['GET'])
-def get_multi_revisions_list(id):
-    # By default, do not return dataset. Only return dataset if include_dataset is true
-    property_key = 'uuid'
-    if bool(request.args):
-        include_dataset = request.args.get('include_dataset')
-        if (include_dataset is not None) and (include_dataset.lower() == 'true'):
-            property_key = None
-    # Token is not required, but if an invalid token provided,
-    # we need to tell the client with a 401 error
-    validate_token_if_auth_header_exists(request)
-
-    # Use the internal token to query the target entity
-    # since public entities don't require user token
-    token = get_internal_token()
-
-    # Query target entity against uuid-api and neo4j and return as a dict if exists
-    entity_dict = query_target_entity(id, token)
-    normalized_entity_type = entity_dict['entity_type']
-
-    # Only for Dataset
-    if not schema_manager.entity_type_instanceof(normalized_entity_type, 'Dataset'):
-        abort_bad_req("The entity is not a Dataset. Found entity type:" + normalized_entity_type)
-
-    # Only published/public datasets don't require token
-    if entity_dict['status'].lower() != DATASET_STATUS_PUBLISHED:
-        # Token is required and the user must belong to HuBMAP-READ group
-        token = get_user_token(request, non_public_access_required=True)
-
-    # By now, either the entity is public accessible or
-    # the user token has the correct access level
-    # Get the all the sorted (DESC based on creation timestamp) revisions
-    sorted_revisions_list = app_neo4j_queries.get_sorted_multi_revisions(neo4j_driver_instance, entity_dict['uuid'],
-                                                                         fetch_all=user_in_hubmap_read_group(request),
-                                                                         property_key=property_key)
-
-    # Skip some of the properties that are time-consuming to generate via triggers
-    properties_to_skip = [
-        'direct_ancestors',
-        'collections',
-        'upload',
-        'title'
-    ]
-
-    normalized_revisions_list = []
-    sorted_revisions_list_merged = sorted_revisions_list[0] + sorted_revisions_list[1][::-1]
-
-    if property_key is None:
-        for revision in sorted_revisions_list_merged:
-            complete_revision_list = schema_manager.get_complete_entities_list(token, revision, properties_to_skip)
-            normal = schema_manager.normalize_entities_list_for_response(complete_revision_list)
-            normalized_revisions_list.append(normal)
-    else:
-        normalized_revisions_list = sorted_revisions_list_merged
-
-    # Now all we need to do is to compose the result list
-    results = []
-    revision_number = len(normalized_revisions_list)
-    for revision in normalized_revisions_list:
-        result = {
-            'revision_number': revision_number,
-            'uuids': revision
-        }
-        results.append(result)
-        revision_number -= 1
-
-    return jsonify(results)
+# """
+# Retrieve a list of all multi revisions of a dataset from the id of any dataset in the chain.
+# E.g: If there are 5 revisions, and the id for revision 4 is given, a list of revisions
+# 1-5 will be returned in reverse order (newest first). Non-public access is only required to
+# retrieve information on non-published datasets. Output will be a list of dictionaries. Each dictionary
+# contains the dataset revision number and its list of uuids. Optionally, the full dataset can be included for each.
+#
+# By default, only the revision number and uuids are included. To include the full dataset, the query
+# parameter "include_dataset" can be given with the value of "true". If this parameter is not included or
+# is set to false, the dataset will not be included. For example, to include the full datasets for each revision,
+# use '/datasets/<id>/multi-revisions?include_dataset=true'. To omit the datasets, either set include_dataset=false, or
+# simply do not include this parameter.
+#
+# Parameters
+# ----------
+# id : str
+#     The HuBMAP ID (e.g. HBM123.ABCD.456) or UUID of target dataset
+#
+# Returns
+# -------
+# list
+#     The list of revision datasets
+# """
+# @app.route('/entities/<id>/multi-revisions', methods=['GET'])
+# @app.route('/datasets/<id>/multi-revisions', methods=['GET'])
+# def get_multi_revisions_list(id):
+#     # By default, do not return dataset. Only return dataset if include_dataset is true
+#     property_key = 'uuid'
+#     if bool(request.args):
+#         include_dataset = request.args.get('include_dataset')
+#         if (include_dataset is not None) and (include_dataset.lower() == 'true'):
+#             property_key = None
+#     # Token is not required, but if an invalid token provided,
+#     # we need to tell the client with a 401 error
+#     validate_token_if_auth_header_exists(request)
+#
+#     # Use the internal token to query the target entity
+#     # since public entities don't require user token
+#     token = get_internal_token()
+#
+#     # Query target entity against uuid-api and neo4j and return as a dict if exists
+#     entity_dict = query_target_entity(id, token)
+#     normalized_entity_type = entity_dict['entity_type']
+#
+#     # Only for Dataset
+#     if not schema_manager.entity_type_instanceof(normalized_entity_type, 'Dataset'):
+#         abort_bad_req("The entity is not a Dataset. Found entity type:" + normalized_entity_type)
+#
+#     # Only published/public datasets don't require token
+#     if entity_dict['status'].lower() != DATASET_STATUS_PUBLISHED:
+#         # Token is required and the user must belong to HuBMAP-READ group
+#         token = get_user_token(request, non_public_access_required=True)
+#
+#     # By now, either the entity is public accessible or
+#     # the user token has the correct access level
+#     # Get the all the sorted (DESC based on creation timestamp) revisions
+#     sorted_revisions_list = app_neo4j_queries.get_sorted_multi_revisions(neo4j_driver_instance, entity_dict['uuid'],
+#                                                                          fetch_all=user_in_hubmap_read_group(request),
+#                                                                          property_key=property_key)
+#
+#     # Skip some of the properties that are time-consuming to generate via triggers
+#     properties_to_skip = [
+#         'direct_ancestors',
+#         'collections',
+#         'upload',
+#         'title'
+#     ]
+#
+#     normalized_revisions_list = []
+#     sorted_revisions_list_merged = sorted_revisions_list[0] + sorted_revisions_list[1][::-1]
+#
+#     if property_key is None:
+#         for revision in sorted_revisions_list_merged:
+#             complete_revision_list = schema_manager.get_complete_entities_list(token, revision, properties_to_skip)
+#             normal = schema_manager.normalize_entities_list_for_response(complete_revision_list)
+#             normalized_revisions_list.append(normal)
+#     else:
+#         normalized_revisions_list = sorted_revisions_list_merged
+#
+#     # Now all we need to do is to compose the result list
+#     results = []
+#     revision_number = len(normalized_revisions_list)
+#     for revision in normalized_revisions_list:
+#         result = {
+#             'revision_number': revision_number,
+#             'uuids': revision
+#         }
+#         results.append(result)
+#         revision_number -= 1
+#
+#     return jsonify(results)
 
 
 

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -445,17 +445,11 @@ ENTITIES:
         transient: true
         immutable: true
         description: "The uuid of previous revision dataset"
+        before_property_create_validators:
+          - validate_if_revision_is_unique
         after_create_trigger: link_to_previous_revision
         on_read_trigger: get_previous_revision_uuid
         on_index_trigger: get_previous_revision_uuid
-      previous_revision_uuids:
-        type: list
-        generated: true
-        transient: true
-        immutable: true
-        description: "The list of the uuids of previous revision datasets"
-        on_read_trigger: get_previous_revision_uuids
-        # No on_index_trigger to include previous_revision_uuids in the OpenSearch document for a Dataset
       next_revision_uuid:
         type: string
         generated: true
@@ -464,14 +458,6 @@ ENTITIES:
         description: "The uuid of next revision dataset"
         on_read_trigger: get_next_revision_uuid
         on_index_trigger: get_next_revision_uuid
-      next_revision_uuids:
-        type: list
-        generated: true
-        transient: true
-        immutable: true
-        description: "The list of the uuids of next revision datasets"
-        on_read_trigger: get_next_revision_uuids
-        # No on_index_trigger to include next_revision_uuids in the OpenSearch document for a Dataset
       superseded_associated_processed_component_uuids:
         type: list
         # This property gets set via a PUT by entity-api /entities/{{dataset_uuid}} to point to the Multi-Assay Dataset

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -488,9 +488,7 @@ ENTITIES:
         description: "The displayname of globus group which the user who created this entity is a member of"
         before_create_trigger: set_group_name #same as group_uuid, except set group_name
       previous_revision_uuid:
-        type:
-          - string
-          - list
+        type: string
         transient: true
         immutable: true
         indexed: true

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -133,15 +133,10 @@ If the provided previous revision is already a revision of another dataset, disa
 def validate_if_revision_is_unique(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
     previous_revision = new_data_dict['previous_revision_uuid']
     neo4j_driver_instance = schema_manager.get_neo4j_driver_instance()
-    if isinstance(previous_revision, list):
-        previous_revision_uuid = previous_revision[0]
-    else:
-        previous_revision_uuid = previous_revision
-    next_revision = schema_neo4j_queries.get_next_revision_uuid(neo4j_driver_instance, previous_revision_uuid)
+    next_revision = schema_neo4j_queries.get_next_revision_uuid(neo4j_driver_instance, previous_revision)
     if next_revision:
         raise ValueError(f"Dataset marked as previous revision is already the previous revision of another dataset. "
                          f"Each dataset may only be the previous revision of one other dataset")
-
 
 
 """

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -128,6 +128,23 @@ def validate_dataset_not_component(property_key, normalized_entity_type, request
 
 
 """
+If the provided previous revision is already a revision of another dataset, disallow
+"""
+def validate_if_revision_is_unique(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):
+    previous_revision = new_data_dict['previous_revision_uuid']
+    neo4j_driver_instance = schema_manager.get_neo4j_driver_instance()
+    if isinstance(previous_revision, list):
+        previous_revision_uuid = previous_revision[0]
+    else:
+        previous_revision_uuid = previous_revision
+    next_revision = schema_neo4j_queries.get_next_revision_uuid(neo4j_driver_instance, previous_revision_uuid)
+    if next_revision:
+        raise ValueError(f"Dataset marked as previous revision is already the previous revision of another dataset. "
+                         f"Each dataset may only be the previous revision of one other dataset")
+
+
+
+"""
 If an entity has a DOI, do not allow it to be updated 
 """
 def halt_update_if_DOI_exists(property_key, normalized_entity_type, request, existing_data_dict, new_data_dict):


### PR DESCRIPTION
Removed the ability to include multiple previous revision id's when creating or updating an entity. 

Added validator that sees if a provided previous revision already has a revision itself and raises a value error if it does. 

Still allow previous_revision_uuid value to be a list or a string, if its a list, its just constrained to a single entry for the sake of compatibility. 

Left any underlying schema queries or other methods intact in case we need to use them later, just removed their uses in app.py and the provenance schema. 

Commented out the endpoint GET multi-revisions rather than deleting in case we need to add it back later. 