### PR TITLE
Derek furst/constraints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+import sys
 import collections
 import yaml
 from typing import List
@@ -2294,6 +2295,9 @@ def validate_constraints():
     if not request.is_json:
         bad_request_error("A json body and appropriate Content-Type header are required")
     json_entry = request.get_json()
+    is_valid = constraints_json_is_valid(json_entry)
+    if is_valid is not True:
+        bad_request_error(is_valid)
     is_match = request.values.get('match')
     order = request.values.get('order')
 
@@ -4341,6 +4345,35 @@ err_msg : str
 """
 def internal_server_error(err_msg):
     abort(500, description = err_msg)
+
+
+"""
+Validates the incoming json for the endpoint /constraints. 
+Returns true if the json matches the required format. If 
+invalid, returns a string explaining why.
+"""
+def constraints_json_is_valid(json_entry):
+    if not isinstance(json_entry, list):
+        return "JSON body expects a list."
+    
+    for constraint in json_entry:
+        if not isinstance(constraint, dict):
+            return "Each constraint in the list must be a JSON object."
+
+        for key in constraint:
+            if key not in ["ancestors", "descendants"]:
+                return f"Invalid key '{key}'. Allowed keys are 'ancestors' and 'descendants'."
+            
+            value = constraint[key]
+            if isinstance(value, dict):
+                continue
+            elif isinstance(value, list):
+                for item in value:
+                    if not isinstance(item, dict):
+                        return f"The value for '{key}' must be represented as a JSON object or as a list of objects"
+            else:
+                return f"The value for '{key}' must be a JSON object or a list of JSON objects."
+    return True
 
 
 """

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,3 @@
-import sys
 import collections
 import yaml
 from typing import List


### PR DESCRIPTION
Added validator to confirm json body for constraints endpoint matches expected format. 

Specific values and fields are validated later on, this function confirms that the request body is a json list, where each entry in the list is a json object representing a constraint. Each constraint can only have the keys "ancestors" or "descendants". Ancestors and descendants values must be dictionaries or lists of dictionaries. 