### PR TITLE
Updates to Derek-Furst/constraints

### DIFF
--- a/src/metadata_constraints.py
+++ b/src/metadata_constraints.py
@@ -195,6 +195,10 @@ def get_constraint_unit_as_list(entry):
 # Validates based on exclusions. Example constraint:
 # build_constraint_unit(entity, [SpecimenCategory.BLOCK], ['!', Organs.BLOOD])
 def validate_exclusions(entry, constraint, key) -> bool:
+    if type(entry) is list:
+        entry = entry[0]
+    if type(constraint) is list:
+        constraint = constraint[0]
     if key == "entity_type":
         entry_key = [entry.get(key)]
     else:
@@ -240,7 +244,7 @@ def get_constraints(entry, key1, key2, is_match=False) -> dict:
                         result = {'code': 200, 'name': 'OK', 'description': const_key2}
                     else:
                         # This weeds out organ:dataset but allows all other organ-as-ancestor pairs
-                        included = validate_exclusions(entry_key2[0], const_key2[0], "entity_type")
+                        included = validate_exclusions(entry_key2, const_key2, "entity_type")
                         if included:
                             result = {'code': 200, 'name': "No Constraints", 'description': f"Exclusion constraint not triggered for given {key2} check. Entry: {entry_key2} / Excluded types: {const_key2}"}
                         else:


### PR DESCRIPTION
This PR updates previous work on the constraints endpoint to do the following:
- Return a 200 for valid entity types (e.g. dataset, publication, etc.) that do not have constraints.
- Allow an organ to be an ancestor of other entities (except datasets) rather than just a descendant of donor.
- Handle sub_types/sub_type_vals in cases where the constraint has a required sub_type and/or sub_type_val

One uncertainty:
- Different code paths are followed for a request with the URL parameter `order=ancestors` (the default) vs. `order=descendants`. Whichever order is selected (ancestors or descendants), that key in the payload is evaluated first. So if you pass an allowable* entity_type ancestor in an `order=ancestor` request, but that entity_type doesn't have constraints, you will get a 200 back *regardless of whether the descendant is an allowable entity type.* This is probably functionally fine but also could lead to a positive response for the following:
```
curl --location 'http://entity.api.hubmapconsortium.org/constraints?match=True&order=descendants' \
--header 'Authorization: Bearer <token>' \
--header 'Content-Type: application/json' \
--data '[
    {
        "ancestors": [{
            "entity_type": "asdfasdf",
            "sub_type": ["blah"],
            "sub_type_val": "bad"
        }],
        "descendants": [{
            "entity_type": "sample",
            "sub_type": ["block"],
            "sub_type_val": null
        }]
    }
]'
```

```
{
    "code": 200,
    "description": [
        {
            "code": 200,
            "description": "No constraints exist for given descendants: {'entity_type': 'sample', 'sub_type': ['block'], 'sub_type_val': None}",
            "name": "No Constraints"
        }
    ],
    "name": "ok"
}
```

IVT doesn't use `order=descendants` so that could be unsupported for the time being if you don't have plans to use it either. IVT requires the param `order=ancestors` to be valid. This problem solves itself if a comprehensive set of constraints is added down the line.

*allowable meaning part of `entities = ['dataset', 'sample', 'donor', 'publication', 'upload']`