### PR TITLE
Created a temporary override in dataset type validator for datasets t…

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -667,10 +667,6 @@ ENTITIES:
         description: "The activity that was performed."
       dataset_type:
         before_create_trigger: set_publication_dataset_type
-        before_property_create_validators:
-          - validate_recognized_dataset_type
-        before_property_update_validators:
-          - validate_recognized_dataset_type
         type: string
         generated: true
         immutable: true

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -68,7 +68,8 @@ def validate_recognized_dataset_type(property_key, normalized_entity_type, reque
     # those square brackets are acceptable at the end of the string.  Simply validate the start.
     proposed_dataset_type_prefix = re.sub(pattern='(\S)\s\[.*\]$', repl=r'\1', string=new_data_dict['dataset_type'])
     target_list = schema_manager.get_dataset_type_valueset_list()
-
+    # TODO This is a temporary bypass because the UBKG does not support publication as a dataset_type yet. Remove once its added
+    target_list.append("Publication")
     if proposed_dataset_type_prefix not in target_list:
         raise ValueError(f"Proposed Dataset dataset_type '{proposed_dataset_type_prefix}'"
                          f" is not recognized in the existing ontology."


### PR DESCRIPTION
Created a temporary override in dataset type validator for datasets to allow publication (as well as derivatives like publication [ancillary]) to pass. Removed validators from publication because its a generated field anyway