### PR TITLE
Correct field exclusion for public responses, except for direct_ancestor problem

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,7 +18,7 @@ PyYAML==5.4.1
 # Use the branch name of commons from github for testing new changes made in commons from different branch
 # Default is main branch specified in docker-compose.development.yml if not set
 # git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
-hubmap-commons==2.1.18
+hubmap-commons==2.1.19
 
 # For unit test
 nose2==0.10.0


### PR DESCRIPTION
Fix authorization problems to get correct field exclusion for public responses, except for known direct_ancestor problem.