### PR TITLE
New fields to exclude from public responses

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -201,6 +201,12 @@ ENTITIES:
         - lab_dataset_id
         - metadata:
           - lab_id
+          - acquisition_id
+          - library_id
+          - donor_id
+          - slide_id
+          - tissue_id
+          - parent_sample_id
     # Collection can not be derivation source but not target
     derivation:
       source: false
@@ -316,6 +322,12 @@ ENTITIES:
       - lab_dataset_id
       - metadata:
         - lab_id
+        - acquisition_id
+        - library_id
+        - donor_id
+        - slide_id
+        - tissue_id
+        - parent_sample_id
       - direct_ancestors:
         # Sample ancestors of a Dataset must have these fields removed
         - lab_tissue_sample_id
@@ -325,6 +337,12 @@ ENTITIES:
         # Both Sample and Dataset ancestors of a Dataset must have these fields removed
         - metadata:
           - lab_id
+          - acquisition_id
+          - library_id
+          - donor_id
+          - slide_id
+          - tissue_id
+          - parent_sample_id
     derivation:
       source: true
       target: true


### PR DESCRIPTION
New fields to exclude from public responses.  Did not create a [shared_excluded_properties_from_public_response like SN](https://github.com/sennetconsortium/entity-api/pull/743/files#diff-cd8a3bff2418f86ca995d983b9e0d2ed942f3a2a10b8eb393b15f18f56ea3fb4R84) this time.  Did verify document created by search-api using these changes is correct on Dev.