### PR TITLE
Bump GitHub Action to use Python 3.13 for CI.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.13"
     - name: Upgrade Pip
       run: python -m pip install --upgrade pip
       working-directory: src


### PR DESCRIPTION
Bump GitHub Action to use Python 3.13 for CI.